### PR TITLE
deps: prevent zero-extent Minecraft swapchains

### DIFF
--- a/tools/vk_zero_extent_probe.cpp
+++ b/tools/vk_zero_extent_probe.cpp
@@ -1,0 +1,302 @@
+// Regression probe for zero-area Win32 Vulkan surfaces.
+//
+// A transient 120x0 client area previously reached the software WSI image
+// allocator and produced a zero-sized Venus buffer/memory bind.  The probe
+// verifies that capabilities normalize a partial-zero client area to 0x0,
+// swapchain creation fails before allocation, and creation recovers after
+// resize.  The deliberately stale create requests exercise driver hardening;
+// they are not valid application usage.
+
+#define VK_USE_PLATFORM_WIN32_KHR
+#define VK_NO_PROTOTYPES
+#include <vulkan/vulkan.h>
+#include <windows.h>
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define CHECK_VK(expr)                                                         \
+  do {                                                                         \
+    VkResult result = (expr);                                                  \
+    if (result != VK_SUCCESS) {                                                \
+      fprintf(stderr, "FAIL %s -> %d (line %d)\n", #expr, (int)result,         \
+              __LINE__);                                                       \
+      exit(1);                                                                 \
+    }                                                                          \
+  } while (0)
+
+#define LOAD_INSTANCE_PROC(name)                                               \
+  PFN_##name name = (PFN_##name)(void *)get_instance_proc(instance, #name);    \
+  if (!name) {                                                                 \
+    fprintf(stderr, "FAIL missing instance proc %s\n", #name);                 \
+    return 1;                                                                  \
+  }
+
+#define LOAD_DEVICE_PROC(name)                                                 \
+  PFN_##name name = (PFN_##name)(void *)get_device_proc(device, #name);        \
+  if (!name) {                                                                 \
+    fprintf(stderr, "FAIL missing device proc %s\n", #name);                   \
+    return 1;                                                                  \
+  }
+
+static LRESULT CALLBACK window_proc(HWND hwnd, UINT message, WPARAM wparam,
+                                    LPARAM lparam) {
+  return DefWindowProcA(hwnd, message, wparam, lparam);
+}
+
+static void expect_extent(const char *name, VkExtent2D actual, uint32_t width,
+                          uint32_t height) {
+  if (actual.width != width || actual.height != height) {
+    fprintf(stderr, "FAIL %s is %ux%u, expected %ux%u\n", name, actual.width,
+            actual.height, width, height);
+    exit(1);
+  }
+}
+
+static void expect_result(const char *name, VkResult actual,
+                          VkResult expected) {
+  if (actual != expected) {
+    fprintf(stderr, "FAIL %s -> %d, expected %d\n", name, (int)actual,
+            (int)expected);
+    exit(1);
+  }
+}
+
+int main(int argc, char **argv) {
+  if (argc != 2) {
+    fprintf(stderr, "usage: %s <vulkan ICD DLL>\n", argv[0]);
+    return 2;
+  }
+
+  HMODULE icd = LoadLibraryA(argv[1]);
+  if (!icd) {
+    fprintf(stderr, "FAIL LoadLibraryA(%s) -> %lu\n", argv[1], GetLastError());
+    return 1;
+  }
+  PFN_vkGetInstanceProcAddr get_instance_proc =
+      (PFN_vkGetInstanceProcAddr)(void *)GetProcAddress(
+          icd, "vk_icdGetInstanceProcAddr");
+  if (!get_instance_proc) {
+    fprintf(stderr, "FAIL missing vk_icdGetInstanceProcAddr\n");
+    return 1;
+  }
+  PFN_vkCreateInstance vkCreateInstance =
+      (PFN_vkCreateInstance)(void *)get_instance_proc(VK_NULL_HANDLE,
+                                                      "vkCreateInstance");
+  if (!vkCreateInstance) {
+    fprintf(stderr, "FAIL missing vkCreateInstance\n");
+    return 1;
+  }
+
+  HINSTANCE hinstance = GetModuleHandleA(NULL);
+  WNDCLASSA window_class = {};
+  window_class.lpfnWndProc = window_proc;
+  window_class.hInstance = hinstance;
+  window_class.lpszClassName = "HeliosVkZeroExtentProbe";
+  if (!RegisterClassA(&window_class) &&
+      GetLastError() != ERROR_CLASS_ALREADY_EXISTS) {
+    fprintf(stderr, "FAIL RegisterClassA -> %lu\n", GetLastError());
+    return 1;
+  }
+
+  /* WS_POPUP makes the requested outer and client dimensions identical. */
+  HWND hwnd = CreateWindowExA(0, window_class.lpszClassName,
+                              "helios vk zero-extent probe", WS_POPUP, 0, 0,
+                              120, 0, NULL, NULL, hinstance, NULL);
+  if (!hwnd) {
+    fprintf(stderr, "FAIL CreateWindowExA -> %lu\n", GetLastError());
+    return 1;
+  }
+
+  RECT rect;
+  if (!GetClientRect(hwnd, &rect)) {
+    fprintf(stderr, "FAIL GetClientRect -> %lu\n", GetLastError());
+    return 1;
+  }
+  printf("zero-area client: %ldx%ld\n", rect.right - rect.left,
+         rect.bottom - rect.top);
+  if (rect.right - rect.left <= 0 || rect.bottom - rect.top != 0) {
+    fprintf(
+        stderr,
+        "FAIL probe could not create the required partial-zero client area\n");
+    return 1;
+  }
+
+  const char *instance_extensions[] = {
+      VK_KHR_SURFACE_EXTENSION_NAME,
+      VK_KHR_WIN32_SURFACE_EXTENSION_NAME,
+  };
+  VkApplicationInfo app_info = {};
+  app_info.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
+  app_info.pApplicationName = "vk_zero_extent_probe";
+  app_info.apiVersion = VK_API_VERSION_1_1;
+  VkInstanceCreateInfo instance_info = {};
+  instance_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+  instance_info.pApplicationInfo = &app_info;
+  instance_info.enabledExtensionCount = 2;
+  instance_info.ppEnabledExtensionNames = instance_extensions;
+
+  VkInstance instance = VK_NULL_HANDLE;
+  CHECK_VK(vkCreateInstance(&instance_info, NULL, &instance));
+
+  LOAD_INSTANCE_PROC(vkCreateWin32SurfaceKHR);
+  LOAD_INSTANCE_PROC(vkDestroySurfaceKHR);
+  LOAD_INSTANCE_PROC(vkDestroyInstance);
+  LOAD_INSTANCE_PROC(vkEnumeratePhysicalDevices);
+  LOAD_INSTANCE_PROC(vkGetPhysicalDeviceProperties);
+  LOAD_INSTANCE_PROC(vkGetPhysicalDeviceQueueFamilyProperties);
+  LOAD_INSTANCE_PROC(vkGetPhysicalDeviceSurfaceSupportKHR);
+  LOAD_INSTANCE_PROC(vkGetPhysicalDeviceSurfaceCapabilitiesKHR);
+  LOAD_INSTANCE_PROC(vkGetPhysicalDeviceSurfaceFormatsKHR);
+  LOAD_INSTANCE_PROC(vkCreateDevice);
+  LOAD_INSTANCE_PROC(vkGetDeviceProcAddr);
+
+  VkWin32SurfaceCreateInfoKHR surface_info = {};
+  surface_info.sType = VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR;
+  surface_info.hinstance = hinstance;
+  surface_info.hwnd = hwnd;
+  VkSurfaceKHR surface = VK_NULL_HANDLE;
+  CHECK_VK(vkCreateWin32SurfaceKHR(instance, &surface_info, NULL, &surface));
+
+  uint32_t physical_count = 0;
+  CHECK_VK(vkEnumeratePhysicalDevices(instance, &physical_count, NULL));
+  if (physical_count == 0) {
+    fprintf(stderr, "FAIL no Vulkan physical device\n");
+    return 1;
+  }
+  VkPhysicalDevice *physical_devices =
+      (VkPhysicalDevice *)calloc(physical_count, sizeof(*physical_devices));
+  CHECK_VK(
+      vkEnumeratePhysicalDevices(instance, &physical_count, physical_devices));
+
+  VkPhysicalDevice physical_device = VK_NULL_HANDLE;
+  uint32_t queue_family = UINT32_MAX;
+  for (uint32_t device_index = 0; device_index < physical_count;
+       device_index++) {
+    uint32_t queue_count = 0;
+    vkGetPhysicalDeviceQueueFamilyProperties(physical_devices[device_index],
+                                             &queue_count, NULL);
+    VkQueueFamilyProperties *queues =
+        (VkQueueFamilyProperties *)calloc(queue_count, sizeof(*queues));
+    vkGetPhysicalDeviceQueueFamilyProperties(physical_devices[device_index],
+                                             &queue_count, queues);
+    for (uint32_t i = 0; i < queue_count; i++) {
+      VkBool32 present = VK_FALSE;
+      CHECK_VK(vkGetPhysicalDeviceSurfaceSupportKHR(
+          physical_devices[device_index], i, surface, &present));
+      if (present && (queues[i].queueFlags & VK_QUEUE_GRAPHICS_BIT)) {
+        physical_device = physical_devices[device_index];
+        queue_family = i;
+        break;
+      }
+    }
+    free(queues);
+    if (physical_device != VK_NULL_HANDLE)
+      break;
+  }
+  free(physical_devices);
+  if (queue_family == UINT32_MAX) {
+    fprintf(stderr, "FAIL no graphics/present queue family\n");
+    return 1;
+  }
+
+  VkPhysicalDeviceProperties properties;
+  vkGetPhysicalDeviceProperties(physical_device, &properties);
+  printf("device: %s\n", properties.deviceName);
+
+  VkSurfaceCapabilitiesKHR capabilities;
+  CHECK_VK(vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physical_device, surface,
+                                                     &capabilities));
+  expect_extent("currentExtent", capabilities.currentExtent, 0, 0);
+  expect_extent("minImageExtent", capabilities.minImageExtent, 0, 0);
+  expect_extent("maxImageExtent", capabilities.maxImageExtent, 0, 0);
+
+  uint32_t format_count = 0;
+  CHECK_VK(vkGetPhysicalDeviceSurfaceFormatsKHR(physical_device, surface,
+                                                &format_count, NULL));
+  if (format_count == 0) {
+    fprintf(stderr, "FAIL surface has no formats\n");
+    return 1;
+  }
+  VkSurfaceFormatKHR *formats =
+      (VkSurfaceFormatKHR *)calloc(format_count, sizeof(*formats));
+  CHECK_VK(vkGetPhysicalDeviceSurfaceFormatsKHR(physical_device, surface,
+                                                &format_count, formats));
+
+  float priority = 1.0f;
+  VkDeviceQueueCreateInfo queue_info = {};
+  queue_info.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+  queue_info.queueFamilyIndex = queue_family;
+  queue_info.queueCount = 1;
+  queue_info.pQueuePriorities = &priority;
+  const char *device_extensions[] = {VK_KHR_SWAPCHAIN_EXTENSION_NAME};
+  VkDeviceCreateInfo device_info = {};
+  device_info.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+  device_info.queueCreateInfoCount = 1;
+  device_info.pQueueCreateInfos = &queue_info;
+  device_info.enabledExtensionCount = 1;
+  device_info.ppEnabledExtensionNames = device_extensions;
+  VkDevice device = VK_NULL_HANDLE;
+  CHECK_VK(vkCreateDevice(physical_device, &device_info, NULL, &device));
+  PFN_vkGetDeviceProcAddr get_device_proc = vkGetDeviceProcAddr;
+  LOAD_DEVICE_PROC(vkCreateSwapchainKHR);
+  LOAD_DEVICE_PROC(vkDestroySwapchainKHR);
+  LOAD_DEVICE_PROC(vkDestroyDevice);
+
+  VkSwapchainCreateInfoKHR swapchain_info = {};
+  swapchain_info.sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR;
+  swapchain_info.surface = surface;
+  swapchain_info.minImageCount = capabilities.minImageCount;
+  swapchain_info.imageFormat = formats[0].format;
+  swapchain_info.imageColorSpace = formats[0].colorSpace;
+  swapchain_info.imageExtent = {320, 240}; /* Deliberately stale/nonzero. */
+  swapchain_info.imageArrayLayers = 1;
+  swapchain_info.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+  swapchain_info.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
+  swapchain_info.preTransform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
+  swapchain_info.compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
+  swapchain_info.presentMode = VK_PRESENT_MODE_FIFO_KHR;
+  swapchain_info.clipped = VK_TRUE;
+
+  VkSwapchainKHR swapchain = VK_NULL_HANDLE;
+  VkResult result =
+      vkCreateSwapchainKHR(device, &swapchain_info, NULL, &swapchain);
+  expect_result("zero-area vkCreateSwapchainKHR", result,
+                VK_ERROR_INITIALIZATION_FAILED);
+  printf("zero-area swapchain rejected with VK_ERROR_INITIALIZATION_FAILED\n");
+
+  if (!SetWindowPos(hwnd, NULL, 0, 0, 320, 240,
+                    SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE)) {
+    fprintf(stderr, "FAIL SetWindowPos -> %lu\n", GetLastError());
+    return 1;
+  }
+  CHECK_VK(vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physical_device, surface,
+                                                     &capabilities));
+  expect_extent("restored currentExtent", capabilities.currentExtent, 320, 240);
+  expect_extent("restored minImageExtent", capabilities.minImageExtent, 320,
+                240);
+  expect_extent("restored maxImageExtent", capabilities.maxImageExtent, 320,
+                240);
+
+  swapchain_info.imageExtent = {319, 240};
+  result = vkCreateSwapchainKHR(device, &swapchain_info, NULL, &swapchain);
+  expect_result("stale-size vkCreateSwapchainKHR", result,
+                VK_ERROR_INITIALIZATION_FAILED);
+
+  swapchain_info.imageExtent = capabilities.currentExtent;
+  swapchain_info.minImageCount = capabilities.minImageCount;
+  CHECK_VK(vkCreateSwapchainKHR(device, &swapchain_info, NULL, &swapchain));
+  printf("restored swapchain created at %ux%u\n",
+         capabilities.currentExtent.width, capabilities.currentExtent.height);
+
+  vkDestroySwapchainKHR(device, swapchain, NULL);
+  vkDestroyDevice(device, NULL);
+  free(formats);
+  vkDestroySurfaceKHR(instance, surface, NULL);
+  vkDestroyInstance(instance, NULL);
+  DestroyWindow(hwnd);
+  FreeLibrary(icd);
+  printf("PASS\n");
+  return 0;
+}

--- a/tools/wgl_zero_extent_probe.cpp
+++ b/tools/wgl_zero_extent_probe.cpp
@@ -1,0 +1,197 @@
+// Regression probe for WGL/Zink zero-area Win32 window transitions.
+//
+// Minecraft can create or retain its OpenGL context while the client area is
+// transiently 120x0. WGL must use ordinary offscreen resources while there is
+// no drawable area, then replace them with swapchain-backed resources when the
+// window becomes drawable.
+
+#define WIN32_LEAN_AND_MEAN
+#include <GL/gl.h>
+#include <windows.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static LRESULT CALLBACK window_proc(HWND hwnd, UINT message, WPARAM wparam,
+                                    LPARAM lparam) {
+  return DefWindowProcA(hwnd, message, wparam, lparam);
+}
+
+static void fail(const char *operation) {
+  fprintf(stderr, "FAIL %s (Win32=%lu)\n", operation, GetLastError());
+  ExitProcess(1);
+}
+
+static void pump_messages(void) {
+  MSG message;
+  while (PeekMessageA(&message, NULL, 0, 0, PM_REMOVE)) {
+    TranslateMessage(&message);
+    DispatchMessageA(&message);
+  }
+}
+
+static void set_client_size(HWND hwnd, LONG width, LONG height) {
+  if (!SetWindowPos(hwnd, NULL, 0, 0, width, height,
+                    SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE))
+    fail("SetWindowPos");
+  pump_messages();
+
+  RECT rect;
+  if (!GetClientRect(hwnd, &rect) || rect.right - rect.left != width ||
+      rect.bottom - rect.top != height)
+    fail("set exact client size");
+}
+
+static void render_readback_and_swap(HDC dc, const char *phase, float red,
+                                     float green, float blue,
+                                     unsigned char expected_red,
+                                     unsigned char expected_green,
+                                     unsigned char expected_blue) {
+  glClearColor(red, green, blue, 1.0f);
+  glClear(GL_COLOR_BUFFER_BIT);
+
+  unsigned char pixel[4] = {};
+  glReadPixels(0, 0, 1, 1, GL_RGBA, GL_UNSIGNED_BYTE, pixel);
+  const GLenum error = glGetError();
+  if (error != GL_NO_ERROR) {
+    fprintf(stderr, "FAIL %s render/readback (GL=0x%x)\n", phase,
+            (unsigned)error);
+    ExitProcess(1);
+  }
+
+  if (abs((int)pixel[0] - (int)expected_red) > 2 ||
+      abs((int)pixel[1] - (int)expected_green) > 2 ||
+      abs((int)pixel[2] - (int)expected_blue) > 2 || pixel[3] < 253) {
+    fprintf(stderr, "FAIL %s color (RGBA=%u,%u,%u,%u)\n", phase, pixel[0],
+            pixel[1], pixel[2], pixel[3]);
+    ExitProcess(1);
+  }
+
+  if (!SwapBuffers(dc))
+    fail(phase);
+  printf("%s succeeded (RGBA=%u,%u,%u,%u)\n", phase, pixel[0], pixel[1],
+         pixel[2], pixel[3]);
+}
+
+int main(int argc, char **argv) {
+  if (argc > 2) {
+    fprintf(stderr, "usage: %s [expected WGL ICD path]\n", argv[0]);
+    return 2;
+  }
+
+  HINSTANCE hinstance = GetModuleHandleA(NULL);
+  WNDCLASSA window_class = {};
+  window_class.lpfnWndProc = window_proc;
+  window_class.hInstance = hinstance;
+  window_class.lpszClassName = "HeliosWglZeroExtentProbe";
+  if (!RegisterClassA(&window_class) &&
+      GetLastError() != ERROR_CLASS_ALREADY_EXISTS)
+    fail("RegisterClassA");
+
+  HWND hwnd = CreateWindowExA(0, window_class.lpszClassName,
+                              "helios WGL zero-extent probe", WS_POPUP, 0, 0,
+                              120, 0, NULL, NULL, hinstance, NULL);
+  if (!hwnd)
+    fail("CreateWindowExA");
+
+  RECT rect;
+  if (!GetClientRect(hwnd, &rect))
+    fail("GetClientRect");
+  printf("zero-area client: %ldx%ld\n", rect.right - rect.left,
+         rect.bottom - rect.top);
+  if (rect.right - rect.left <= 0 || rect.bottom - rect.top != 0)
+    fail("create 120x0 client area");
+
+  HDC dc = GetDC(hwnd);
+  if (!dc)
+    fail("GetDC");
+
+  PIXELFORMATDESCRIPTOR descriptor = {};
+  descriptor.nSize = sizeof(descriptor);
+  descriptor.nVersion = 1;
+  descriptor.dwFlags =
+      PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER;
+  descriptor.iPixelType = PFD_TYPE_RGBA;
+  descriptor.cColorBits = 32;
+  descriptor.cDepthBits = 24;
+  descriptor.cStencilBits = 8;
+  descriptor.iLayerType = PFD_MAIN_PLANE;
+  const int format = ChoosePixelFormat(dc, &descriptor);
+  if (!format || !SetPixelFormat(dc, format, &descriptor))
+    fail("set pixel format");
+
+  HGLRC context = wglCreateContext(dc);
+  if (!context || !wglMakeCurrent(dc, context))
+    fail("create/make-current WGL context");
+
+  HMODULE opengl = GetModuleHandleA("opengl32.dll");
+  HMODULE wgl = GetModuleHandleA("libgallium_wgl.dll");
+  char executable_path[MAX_PATH] = {};
+  char opengl_path[MAX_PATH] = {};
+  char wgl_path[MAX_PATH] = {};
+  if (!opengl || !wgl ||
+      !GetModuleFileNameA(NULL, executable_path, sizeof(executable_path)) ||
+      !GetModuleFileNameA(opengl, opengl_path, sizeof(opengl_path)) ||
+      !GetModuleFileNameA(wgl, wgl_path, sizeof(wgl_path)))
+    fail("resolve graphics module paths");
+
+  char *executable_name = strrchr(executable_path, '\\');
+  char *opengl_name = strrchr(opengl_path, '\\');
+  if (!executable_name || !opengl_name)
+    fail("parse module paths");
+  *executable_name = '\0';
+  *opengl_name = '\0';
+  if (argc == 1 && _stricmp(executable_path, opengl_path) != 0)
+    fail("load app-local OpenGL DLL");
+  if (argc == 2 && _stricmp(argv[1], wgl_path) != 0) {
+    fprintf(stderr, "FAIL loaded WGL ICD %s, expected %s\n", wgl_path, argv[1]);
+    return 1;
+  }
+
+  const char *renderer = (const char *)glGetString(GL_RENDERER);
+  if (!renderer || !strstr(renderer, "zink"))
+    fail("select Zink renderer");
+  printf("OpenGL DLL directory: %s\n", opengl_path);
+  printf("WGL ICD: %s\n", wgl_path);
+  printf("renderer: %s\n", renderer);
+
+  /* Validate the initial context-creation edge that triggered Minecraft. */
+  glViewport(0, 0, 1, 1);
+  render_readback_and_swap(dc, "initial 120x0 offscreen render", 0.25f, 0.5f,
+                           0.75f, 64, 128, 191);
+
+  set_client_size(hwnd, 320, 240);
+  ShowWindow(hwnd, SW_SHOW);
+  pump_messages();
+  glViewport(0, 0, 320, 240);
+  render_readback_and_swap(dc, "initial 320x240 drawable render", 0.1f, 0.2f,
+                           0.3f, 26, 51, 77);
+
+  /* Exercise drawable -> offscreen -> same-size drawable transitions. The
+   * preserved framebuffer dimensions remain 320x240 throughout, so passing
+   * requires backing resources to be recreated for state, not just size.
+   */
+  for (unsigned cycle = 0; cycle < 2; cycle++) {
+    set_client_size(hwnd, 120, 0);
+    glViewport(0, 0, 1, 1);
+    render_readback_and_swap(dc, "transition 120x0 offscreen render", 0.4f,
+                             0.3f, 0.2f, 102, 77, 51);
+
+    set_client_size(hwnd, 320, 240);
+    glViewport(0, 0, 320, 240);
+    render_readback_and_swap(dc, "same-size 320x240 drawable restore", 0.2f,
+                             0.4f, 0.6f, 51, 102, 153);
+  }
+
+  glFinish();
+  if (glGetError() != GL_NO_ERROR)
+    fail("finish restored rendering");
+
+  wglMakeCurrent(NULL, NULL);
+  wglDeleteContext(context);
+  ReleaseDC(hwnd, dc);
+  DestroyWindow(hwnd);
+  printf("PASS\n");
+  return 0;
+}


### PR DESCRIPTION
## Summary

- advance mesa-helios to winboat-org/mesa-helios#4
- add a direct Vulkan ICD regression probe for partial-zero Win32 surfaces
- add a WGL/Zink regression probe for zero-area and same-size restore transitions

## Validation

- production Windows Mesa build completed
- both regression probes pass on the Windows guest
- post-reboot system Vulkan and WGL resolution checks load the revised driver
- Minecraft confirmed working by the reporter
- senior graphics-driver review found no blockers (9/10 implementation and confidence)
- no host driver or configuration changes

Mesa change: https://github.com/winboat-org/mesa-helios/pull/4