### PR TITLE
ci: fix clspv trap on arrays of global pointers

### DIFF
--- a/ci/patches/clspv/0001-lower-pointer-array-alloca.patch
+++ b/ci/patches/clspv/0001-lower-pointer-array-alloca.patch
@@ -11,27 +11,30 @@ index c458729..93a9ad9 100644
    ${CMAKE_CURRENT_SOURCE_DIR}/MultiVersionUBOFunctionsPass.cpp
    ${CMAKE_CURRENT_SOURCE_DIR}/NativeMathPass.cpp
 diff --git a/lib/Compiler.cpp b/lib/Compiler.cpp
-index e059dfd..38061f3 100644
+index e059dfd..9583f7a 100644
 --- a/lib/Compiler.cpp
 +++ b/lib/Compiler.cpp
-@@ -840,6 +840,11 @@ int RunPassPipeline(llvm::Module &M, llvm::raw_svector_ostream *binaryStream) {
-       pm.addPass(llvm::createModuleToFunctionPassAdaptor(llvm::DCEPass()));
-     }
- 
+@@ -801,6 +801,14 @@ int RunPassPipeline(llvm::Module &M, llvm::raw_svector_ostream *binaryStream) {
+     // various types.
+     pm.addPass(clspv::SpecializeImageTypesPass());
+     // This should be run after LLVM and OpenCL intrinsics are replaced.
 +    // Arrays of pointers have no representation in the logical addressing
-+    // model. SROA has already removed the ones it could; this removes the rest
-+    // so that the producer never has to type a pointer held in memory.
++    // model. SROA has already removed the ones it could; this removes the
++    // rest so that the producer never has to type a pointer held in memory.
++    // It must precede AllocateDescriptorsPass: a kernel argument whose only
++    // use is a store into such an array cannot be typed by InferType, and the
++    // descriptor allocator asserts on that before the producer is reached.
 +    pm.addPass(clspv::LowerPointerArrayAllocaPass());
 +
-     // This pass needs to run before an interation of
-     // SimplifyPointerBitcastPass/ReplacePointerBitcastPass.
-     pm.addPass(clspv::LowerPrivatePointerPHIPass());
+     pm.addPass(clspv::AllocateDescriptorsPass());
+     pm.addPass(llvm::VerifierPass());
+     pm.addPass(clspv::DirectResourceAccessPass());
 diff --git a/lib/LowerPointerArrayAllocaPass.cpp b/lib/LowerPointerArrayAllocaPass.cpp
 new file mode 100644
-index 0000000..9ecf425
+index 0000000..241fc6d
 --- /dev/null
 +++ b/lib/LowerPointerArrayAllocaPass.cpp
-@@ -0,0 +1,262 @@
+@@ -0,0 +1,348 @@
 +// Copyright 2026 The Clspv Authors. All rights reserved.
 +//
 +// Licensed under the Apache License, Version 2.0 (the "License");
@@ -46,13 +49,17 @@ index 0000000..9ecf425
 +// See the License for the specific language governing permissions and
 +// limitations under the License.
 +
++#include "llvm/ADT/SetVector.h"
 +#include "llvm/ADT/SmallVector.h"
 +#include "llvm/IR/Dominators.h"
 +#include "llvm/IR/IRBuilder.h"
 +#include "llvm/IR/Instructions.h"
++#include "llvm/IR/IntrinsicInst.h"
 +#include "llvm/IR/Module.h"
++#include "llvm/Support/MathExtras.h"
 +#include "llvm/Transforms/Utils/PromoteMemToReg.h"
 +
++#include "Constants.h"
 +#include "LowerPointerArrayAllocaPass.h"
 +
 +using namespace llvm;
@@ -61,80 +68,145 @@ index 0000000..9ecf425
 +
 +// A select chain is linear in the number of elements, so a very large pointer
 +// table would trade one unrepresentable construct for a great deal of code. In
-+// practice these tables are small (one entry per image plane); refuse to
-+// rewrite anything unreasonable and leave it to the producer to report.
++// practice these tables are small (one entry per image plane); anything larger
++// is refused.
 +constexpr uint64_t kMaxElements = 64;
 +
-+// Returns the element index of |gep| if it is a well formed access to the
-+// pointer array, i.e. `getelementptr [N x ptr], ptr %alloca, i32 0, idx`.
-+// |index_out| is set to the second operand, which may or may not be constant.
-+bool isElementGEP(GetElementPtrInst *gep, AllocaInst *alloca,
-+                  ArrayType *array_ty, Value **index_out) {
-+  if (gep->getPointerOperand() != alloca) {
-+    return false;
-+  }
-+  if (gep->getSourceElementType() != array_ty) {
-+    return false;
-+  }
-+  if (gep->getNumIndices() != 2) {
-+    return false;
-+  }
-+  auto *first = dyn_cast<ConstantInt>(gep->getOperand(1));
-+  if (first == nullptr || !first->isZero()) {
-+    return false;
-+  }
-+  *index_out = gep->getOperand(2);
-+  return true;
-+}
++// Element accesses are compared against constant indices. A narrow index type
++// cannot represent every element number -- an i1 index into a 4-element array
++// is legal IR -- so comparisons are built in a type wide enough for the whole
++// range.
++constexpr unsigned kIndexBits = 32;
 +
 +} // namespace
 +
++bool clspv::LowerPointerArrayAllocaPass::isElementAccess(
++    Value *user, AllocaInst *alloca, ArrayType *array_ty,
++    Value **index_out) const {
++  auto *element_ty = array_ty->getElementType();
++
++  // A load or store directly on the alloca addresses element zero.
++  if (isa<LoadInst>(user) || isa<StoreInst>(user)) {
++    *index_out = nullptr; // constant zero
++    return true;
++  }
++
++  auto *gep = dyn_cast<GetElementPtrInst>(user);
++  if (gep == nullptr || gep->getPointerOperand() != alloca) {
++    return false;
++  }
++
++  if (gep->getNumIndices() == 2) {
++    // The canonical form: getelementptr [N x ptr], ptr %alloca, i32 0, idx
++    if (gep->getSourceElementType() != array_ty) {
++      return false;
++    }
++    auto *first = dyn_cast<ConstantInt>(gep->getOperand(1));
++    if (first == nullptr || !first->isZero()) {
++      return false;
++    }
++    *index_out = gep->getOperand(2);
++    return true;
++  }
++
++  if (gep->getNumIndices() == 1) {
++    // The form LLVM produces once it has folded away the zero index:
++    // getelementptr ptr addrspace(A), ptr %alloca, idx
++    if (gep->getSourceElementType() != element_ty) {
++      return false;
++    }
++    *index_out = gep->getOperand(1);
++    return true;
++  }
++
++  return false;
++}
++
 +bool clspv::LowerPointerArrayAllocaPass::isSupportedAccessPattern(
 +    AllocaInst *alloca, ArrayType *array_ty) const {
++  auto *element_ty = array_ty->getElementType();
++
++  // Arrays of private pointers are handed to LowerPrivatePointerPHIPass, which
++  // cannot select between pointers derived from different allocas. Scalarizing
++  // them would replace one unrepresentable construct with a worse failure, so
++  // they are left exactly as they are.
++  if (element_ty->getPointerAddressSpace() == clspv::AddressSpace::Private) {
++    return false;
++  }
++
 +  for (auto *user : alloca->users()) {
-+    auto *gep = dyn_cast<GetElementPtrInst>(user);
-+    if (gep == nullptr) {
-+      // The array itself is loaded, stored, passed to a call or otherwise
-+      // escapes; scalarizing would not be sound.
++    // Lifetime markers carry no data and are simply dropped; clang emits them
++    // around ordinary local arrays, so refusing them would reject most real
++    // input.
++    if (auto *intrinsic = dyn_cast<IntrinsicInst>(user)) {
++      if (intrinsic->getIntrinsicID() == Intrinsic::lifetime_start ||
++          intrinsic->getIntrinsicID() == Intrinsic::lifetime_end) {
++        continue;
++      }
 +      return false;
 +    }
++
 +    Value *index = nullptr;
-+    if (!isElementGEP(gep, alloca, array_ty, &index)) {
++    if (!isElementAccess(user, alloca, array_ty, &index)) {
++      // The array itself is passed to a call, cast, or otherwise escapes.
 +      return false;
 +    }
-+    if (auto *constant = dyn_cast<ConstantInt>(index)) {
-+      if (constant->getValue().uge(array_ty->getNumElements())) {
++
++    if (index != nullptr) {
++      if (!index->getType()->isIntegerTy()) {
 +        return false;
 +      }
++      if (auto *constant = dyn_cast<ConstantInt>(index)) {
++        if (constant->getValue().uge(array_ty->getNumElements())) {
++          return false;
++        }
++      }
 +    }
-+    // Only whole-element accesses can be redirected to a scalar alloca.
-+    for (auto *gep_user : gep->users()) {
-+      if (auto *load = dyn_cast<LoadInst>(gep_user)) {
-+        if (load->getType() != array_ty->getElementType()) {
-+          return false;
-+        }
-+        if (!load->isSimple()) {
-+          return false;
-+        }
-+      } else if (auto *store = dyn_cast<StoreInst>(gep_user)) {
-+        // Storing the element is fine; storing the *address* of the element
-+        // elsewhere is not.
-+        if (store->getPointerOperand() != gep) {
-+          return false;
-+        }
-+        if (store->getValueOperand()->getType() !=
-+            array_ty->getElementType()) {
-+          return false;
-+        }
-+        if (!store->isSimple()) {
-+          return false;
-+        }
-+      } else {
++
++    // Direct load/store on the alloca is itself the access; a GEP's users are.
++    if (isa<LoadInst>(user) || isa<StoreInst>(user)) {
++      if (!isWholeElementAccess(user, element_ty, /* address */ alloca)) {
++        return false;
++      }
++      continue;
++    }
++
++    for (auto *access : user->users()) {
++      if (!isWholeElementAccess(access, element_ty, /* address */ user)) {
 +        return false;
 +      }
 +    }
 +  }
 +  return true;
++}
++
++bool clspv::LowerPointerArrayAllocaPass::isWholeElementAccess(
++    Value *access, Type *element_ty, Value *address) const {
++  if (auto *load = dyn_cast<LoadInst>(access)) {
++    return load->isSimple() && load->getType() == element_ty &&
++           load->getPointerOperand() == address;
++  }
++  if (auto *store = dyn_cast<StoreInst>(access)) {
++    // The element may be written through this address, but the address itself
++    // must not be written anywhere -- including into its own slot, which would
++    // otherwise place the same instruction in the erase list twice.
++    return store->isSimple() &&
++           store->getValueOperand()->getType() == element_ty &&
++           store->getPointerOperand() == address &&
++           store->getValueOperand() != address;
++  }
++  return false;
++}
++
++Value *clspv::LowerPointerArrayAllocaPass::normalizeIndex(IRBuilder<> &builder,
++                                                          Value *index) const {
++  if (index == nullptr) {
++    return nullptr;
++  }
++  if (index->getType()->getIntegerBitWidth() >= kIndexBits) {
++    return index;
++  }
++  return builder.CreateZExt(index, builder.getIntNTy(kIndexBits));
 +}
 +
 +void clspv::LowerPointerArrayAllocaPass::scalarize(
@@ -144,71 +216,102 @@ index 0000000..9ecf425
 +  const uint64_t num_elements = array_ty->getNumElements();
 +
 +  IRBuilder<> entry_builder(alloca);
++  const size_t first_scalar = scalars.size();
 +  for (uint64_t i = 0; i < num_elements; i++) {
 +    auto *scalar = entry_builder.CreateAlloca(
-+        element_ty, alloca->getAddressSpace(),
-+        /* ArraySize */ nullptr,
++        element_ty, alloca->getAddressSpace(), /* ArraySize */ nullptr,
 +        alloca->getName() + ".elem" + Twine(i));
 +    scalar->setAlignment(alloca->getAlign());
 +    scalars.push_back(scalar);
 +  }
++  auto element = [&](uint64_t i) { return scalars[first_scalar + i]; };
 +
-+  SmallVector<Instruction *, 16> dead;
++  // An instruction can use its address operand more than once, so the erase
++  // list must not contain duplicates.
++  SmallSetVector<Instruction *, 16> dead;
 +
-+  for (auto *user : llvm::make_early_inc_range(alloca->users())) {
-+    auto *gep = cast<GetElementPtrInst>(user);
++  for (auto *user : make_early_inc_range(alloca->users())) {
++    if (auto *intrinsic = dyn_cast<IntrinsicInst>(user)) {
++      dead.insert(intrinsic);
++      continue;
++    }
++
 +    Value *index = nullptr;
-+    bool ok = isElementGEP(gep, alloca, array_ty, &index);
++    bool ok = isElementAccess(user, alloca, array_ty, &index);
 +    (void)ok;
 +    assert(ok && "access pattern changed since it was validated");
 +
-+    if (auto *constant = dyn_cast<ConstantInt>(index)) {
-+      // Constant index: the access simply becomes an access to that scalar.
-+      gep->replaceAllUsesWith(scalars[constant->getZExtValue()]);
-+      dead.push_back(gep);
++    // A load or store directly on the alloca is element zero.
++    SmallVector<Instruction *, 4> accesses;
++    bool is_direct_access = false;
++    if (isa<LoadInst>(user) || isa<StoreInst>(user)) {
++      accesses.push_back(cast<Instruction>(user));
++      is_direct_access = true;
++    } else {
++      for (auto *access : user->users()) {
++        accesses.push_back(cast<Instruction>(access));
++      }
++    }
++
++    if (index == nullptr || isa<ConstantInt>(index)) {
++      const uint64_t constant_index =
++          (index == nullptr) ? 0 : cast<ConstantInt>(index)->getZExtValue();
++      for (auto *access : accesses) {
++        access->replaceUsesOfWith(
++            isa<LoadInst>(access)
++                ? cast<LoadInst>(access)->getPointerOperand()
++                : cast<StoreInst>(access)->getPointerOperand(),
++            element(constant_index));
++      }
++      if (!is_direct_access) {
++        dead.insert(cast<Instruction>(user));
++      }
 +      continue;
 +    }
 +
 +    // Dynamic index: materialise the value with a select chain instead of an
 +    // address computation.
-+    for (auto *gep_user : llvm::make_early_inc_range(gep->users())) {
-+      if (auto *load = dyn_cast<LoadInst>(gep_user)) {
-+        IRBuilder<> builder(load);
-+        // Start from the last element and fold backwards, so element 0 ends up
-+        // as the outermost condition. An out-of-range index is undefined
-+        // behaviour in OpenCL C, so using the last element as the fallback is
-+        // as good as any other choice.
++    for (auto *access : accesses) {
++      IRBuilder<> builder(access);
++      Value *selector = normalizeIndex(builder, index);
++
++      if (auto *load = dyn_cast<LoadInst>(access)) {
++        // Fold backwards from the last element so element 0 ends up as the
++        // outermost condition. An out-of-range index is undefined behaviour in
++        // OpenCL C, so the last element is as good a fallback as any.
 +        Value *result = builder.CreateLoad(
-+            element_ty, scalars[num_elements - 1],
++            element_ty, element(num_elements - 1),
 +            load->getName() + ".elem" + Twine(num_elements - 1));
 +        for (int64_t i = static_cast<int64_t>(num_elements) - 2; i >= 0; i--) {
-+          Value *candidate =
-+              builder.CreateLoad(element_ty, scalars[i],
-+                                 load->getName() + ".elem" + Twine(i));
++          Value *candidate = builder.CreateLoad(
++              element_ty, element(i), load->getName() + ".elem" + Twine(i));
 +          Value *is_this = builder.CreateICmpEQ(
-+              index, ConstantInt::get(index->getType(), i));
++              selector, ConstantInt::get(selector->getType(), i));
 +          result = builder.CreateSelect(is_this, candidate, result);
 +        }
 +        load->replaceAllUsesWith(result);
-+        dead.push_back(load);
-+      } else {
-+        // Validated above: the only other possibility is a store of the
-+        // element through this address. Update every slot, keeping the old
-+        // value where the index does not match.
-+        auto *store = cast<StoreInst>(gep_user);
-+        IRBuilder<> builder(store);
-+        Value *stored = store->getValueOperand();
-+        for (uint64_t i = 0; i < num_elements; i++) {
-+          Value *current = builder.CreateLoad(element_ty, scalars[i]);
-+          Value *is_this = builder.CreateICmpEQ(
-+              index, ConstantInt::get(index->getType(), i));
-+          builder.CreateStore(builder.CreateSelect(is_this, stored, current),
-+                              scalars[i]);
-+        }
-+        dead.push_back(store);
++        dead.insert(load);
++        continue;
 +      }
++
++      // Validated above: the only other possibility is a store of the element
++      // through this address. Update every slot, keeping the old value where
++      // the index does not match.
++      auto *store = cast<StoreInst>(access);
++      Value *stored = store->getValueOperand();
++      for (uint64_t i = 0; i < num_elements; i++) {
++        Value *current = builder.CreateLoad(element_ty, element(i));
++        Value *is_this = builder.CreateICmpEQ(
++            selector, ConstantInt::get(selector->getType(), i));
++        builder.CreateStore(builder.CreateSelect(is_this, stored, current),
++                            element(i));
++      }
++      dead.insert(store);
 +    }
-+    dead.push_back(gep);
++
++    if (!is_direct_access) {
++      dead.insert(cast<Instruction>(user));
++    }
 +  }
 +
 +  for (auto *instruction : dead) {
@@ -237,51 +340,37 @@ index 0000000..9ecf425
 +    }
 +  }
 +
-+  SmallVector<AllocaInst *, 16> to_promote;
++  // Only the scalars this pass creates are promoted. Promoting pre-existing
++  // pointer allocas would be an unrelated behaviour change, and can manufacture
++  // a select between pointers from distinct allocas that
++  // LowerPrivatePointerPHIPass cannot lower.
++  SmallVector<AllocaInst *, 16> created;
 +  for (auto *alloca : candidates) {
 +    auto *array_ty = cast<ArrayType>(alloca->getAllocatedType());
 +    if (!isSupportedAccessPattern(alloca, array_ty)) {
 +      continue;
 +    }
-+    scalarize(alloca, array_ty, to_promote);
++    scalarize(alloca, array_ty, created);
 +  }
-+
-+  // Scalar allocas of pointers are just as unrepresentable as arrays of them,
-+  // so promote any that are eligible, including ones this pass did not create.
-+  for (auto &BB : F) {
-+    for (auto &I : BB) {
-+      auto *alloca = dyn_cast<AllocaInst>(&I);
-+      if (alloca == nullptr || alloca->isArrayAllocation()) {
-+        continue;
-+      }
-+      if (!alloca->getAllocatedType()->isPointerTy()) {
-+        continue;
-+      }
-+      if (llvm::is_contained(to_promote, alloca)) {
-+        continue;
-+      }
-+      to_promote.push_back(alloca);
-+    }
++  if (created.empty()) {
++    return false;
 +  }
 +
 +  SmallVector<AllocaInst *, 16> promotable;
-+  for (auto *alloca : to_promote) {
++  for (auto *alloca : created) {
 +    if (isAllocaPromotable(alloca)) {
 +      promotable.push_back(alloca);
 +    }
 +  }
-+  if (promotable.empty()) {
-+    return !to_promote.empty();
++  if (!promotable.empty()) {
++    DominatorTree DT(F);
++    PromoteMemToReg(promotable, DT);
 +  }
-+
-+  DominatorTree DT(F);
-+  PromoteMemToReg(promotable, DT);
 +  return true;
 +}
 +
 +PreservedAnalyses
 +clspv::LowerPointerArrayAllocaPass::run(Module &M, ModuleAnalysisManager &) {
-+  PreservedAnalyses PA;
 +  bool changed = false;
 +  for (auto &F : M) {
 +    if (F.isDeclaration()) {
@@ -292,14 +381,14 @@ index 0000000..9ecf425
 +  if (!changed) {
 +    return PreservedAnalyses::all();
 +  }
-+  return PA;
++  return PreservedAnalyses::none();
 +}
 diff --git a/lib/LowerPointerArrayAllocaPass.h b/lib/LowerPointerArrayAllocaPass.h
 new file mode 100644
-index 0000000..9a16863
+index 0000000..9541558
 --- /dev/null
 +++ b/lib/LowerPointerArrayAllocaPass.h
-@@ -0,0 +1,69 @@
+@@ -0,0 +1,87 @@
 +// Copyright 2026 The Clspv Authors. All rights reserved.
 +//
 +// Licensed under the Apache License, Version 2.0 (the "License");
@@ -317,6 +406,7 @@ index 0000000..9a16863
 +#ifndef _CLSPV_LIB_LOWER_POINTER_ARRAY_ALLOCA_PASS_H
 +#define _CLSPV_LIB_LOWER_POINTER_ARRAY_ALLOCA_PASS_H
 +
++#include "llvm/IR/IRBuilder.h"
 +#include "llvm/IR/Instructions.h"
 +#include "llvm/IR/Module.h"
 +#include "llvm/IR/PassManager.h"
@@ -354,14 +444,31 @@ index 0000000..9a16863
 +private:
 +  bool runOnFunction(llvm::Function &F);
 +
-+  // Returns true when every use of |alloca| is an access this pass knows how to
-+  // rewrite: a `getelementptr [N x ptr], ptr %alloca, 0, idx` whose only users
-+  // are loads and stores of the element itself.
++  // Recognises a use of |alloca| that addresses one whole element, in any of
++  // the forms LLVM produces: the canonical two-index getelementptr, the
++  // single-index form left once the leading zero is folded away, and a load or
++  // store directly on the alloca (element zero). |index_out| is set to the
++  // element index, or to null to mean a constant zero.
++  bool isElementAccess(llvm::Value *user, llvm::AllocaInst *alloca,
++                       llvm::ArrayType *array_ty,
++                       llvm::Value **index_out) const;
++
++  // Returns true when |access| reads or writes exactly one element through
++  // |address|, and does not store |address| itself.
++  bool isWholeElementAccess(llvm::Value *access, llvm::Type *element_ty,
++                            llvm::Value *address) const;
++
++  // Returns true when every use of |alloca| is an access this pass knows how
++  // to rewrite soundly.
 +  bool isSupportedAccessPattern(llvm::AllocaInst *alloca,
 +                                llvm::ArrayType *array_ty) const;
 +
++  // Widens |index| when its type is too narrow to hold every element number.
++  llvm::Value *normalizeIndex(llvm::IRBuilder<> &builder,
++                              llvm::Value *index) const;
++
 +  // Replaces |alloca| with one scalar alloca per element, rewriting all
-+  // accesses. Returns the newly created allocas.
++  // accesses. Appends the newly created allocas to |scalars|.
 +  void scalarize(llvm::AllocaInst *alloca, llvm::ArrayType *array_ty,
 +                 llvm::SmallVectorImpl<llvm::AllocaInst *> &scalars);
 +};
@@ -427,6 +534,33 @@ index 0000000..aa67027
 +  store i16 %v, ptr addrspace(1) %out, align 2
 +  ret void
 +}
+diff --git a/test/PointerArrayAlloca/end_to_end_plane_table.cl b/test/PointerArrayAlloca/end_to_end_plane_table.cl
+new file mode 100644
+index 0000000..c16478d
+--- /dev/null
++++ b/test/PointerArrayAlloca/end_to_end_plane_table.cl
+@@ -0,0 +1,21 @@
++// A kernel holding a table of __global pointers indexed dynamically. This is
++// the shape that aborted SPIRVProducerPass with "Unsupported opaque pointer".
++// The plane pointers are only ever used through the table, which additionally
++// requires the lowering to run before AllocateDescriptorsPass: InferType
++// cannot type an argument whose sole use is a store into the array.
++// RUN: clspv %s -o %t.spv
++// RUN: spirv-val --target-env vulkan1.3 %t.spv
++// RUN: spirv-dis %t.spv -o %t.spvasm
++// RUN: FileCheck %s < %t.spvasm
++
++// CHECK: OpSelect
++
++__kernel void plane_table(__global ushort *a, __global ushort *b,
++                          __global ushort *c, int which,
++                          __global uint *out) {
++  __global ushort *planes[3];
++  planes[0] = a;
++  planes[1] = b;
++  planes[2] = c;
++  out[0] = (uint)planes[which][get_global_id(0)];
++}
 diff --git a/test/PointerArrayAlloca/escaping_array_untouched.ll b/test/PointerArrayAlloca/escaping_array_untouched.ll
 new file mode 100644
 index 0000000..61f6382
@@ -454,5 +588,100 @@ index 0000000..61f6382
 +  %g0 = getelementptr [2 x ptr addrspace(1)], ptr %planes, i32 0, i32 0
 +  store ptr addrspace(1) %a, ptr %g0, align 4
 +  call void @use(ptr %planes)
++  ret void
++}
+diff --git a/test/PointerArrayAlloca/lifetime_markers_and_folded_gep.ll b/test/PointerArrayAlloca/lifetime_markers_and_folded_gep.ll
+new file mode 100644
+index 0000000..592a36f
+--- /dev/null
++++ b/test/PointerArrayAlloca/lifetime_markers_and_folded_gep.ll
+@@ -0,0 +1,28 @@
++; Lifetime markers are dropped, and the single-index getelementptr LLVM leaves
++; once it folds away the leading zero is recognised as an element access, as is
++; a load or store applied directly to the alloca (element zero).
++; RUN: clspv-opt %s -o %t.ll --passes=lower-pointer-array-alloca
++; RUN: FileCheck %s < %t.ll
++
++; CHECK-NOT: alloca
++; CHECK-NOT: llvm.lifetime
++; CHECK: select i1
++
++target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-G1"
++target triple = "spirv32-unknown-vulkan"
++
++define ptr addrspace(1) @test(ptr addrspace(1) %a, ptr addrspace(1) %b, i32 %which) {
++entry:
++  %planes = alloca [2 x ptr addrspace(1)], align 4
++  call void @llvm.lifetime.start.p0(i64 8, ptr %planes)
++  store ptr addrspace(1) %a, ptr %planes, align 4
++  %g1 = getelementptr ptr addrspace(1), ptr %planes, i32 1
++  store ptr addrspace(1) %b, ptr %g1, align 4
++  %gd = getelementptr ptr addrspace(1), ptr %planes, i32 %which
++  %v = load ptr addrspace(1), ptr %gd, align 4
++  call void @llvm.lifetime.end.p0(i64 8, ptr %planes)
++  ret ptr addrspace(1) %v
++}
++
++declare void @llvm.lifetime.start.p0(i64, ptr)
++declare void @llvm.lifetime.end.p0(i64, ptr)
+diff --git a/test/PointerArrayAlloca/narrow_index_type.ll b/test/PointerArrayAlloca/narrow_index_type.ll
+new file mode 100644
+index 0000000..0fdef56
+--- /dev/null
++++ b/test/PointerArrayAlloca/narrow_index_type.ll
+@@ -0,0 +1,30 @@
++; An i1 index cannot represent every element of a 4-element array, so the
++; comparisons are built in a wider type. Truncating them would make two slots
++; compare equal and silently shadow one another.
++; RUN: clspv-opt %s -o %t.ll --passes=lower-pointer-array-alloca
++; RUN: FileCheck %s < %t.ll
++
++; CHECK-NOT: alloca
++; CHECK: zext i1 %which to i32
++; CHECK: icmp eq i32
++
++target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-G1"
++target triple = "spirv32-unknown-vulkan"
++
++define ptr addrspace(1) @test(ptr addrspace(1) %a, ptr addrspace(1) %b,
++                              ptr addrspace(1) %c, ptr addrspace(1) %d,
++                              i1 %which) {
++entry:
++  %planes = alloca [4 x ptr addrspace(1)], align 4
++  %g0 = getelementptr [4 x ptr addrspace(1)], ptr %planes, i32 0, i32 0
++  store ptr addrspace(1) %a, ptr %g0, align 4
++  %g1 = getelementptr [4 x ptr addrspace(1)], ptr %planes, i32 0, i32 1
++  store ptr addrspace(1) %b, ptr %g1, align 4
++  %g2 = getelementptr [4 x ptr addrspace(1)], ptr %planes, i32 0, i32 2
++  store ptr addrspace(1) %c, ptr %g2, align 4
++  %g3 = getelementptr [4 x ptr addrspace(1)], ptr %planes, i32 0, i32 3
++  store ptr addrspace(1) %d, ptr %g3, align 4
++  %gd = getelementptr [4 x ptr addrspace(1)], ptr %planes, i32 0, i1 %which
++  %v = load ptr addrspace(1), ptr %gd, align 4
++  ret ptr addrspace(1) %v
++}
+diff --git a/test/PointerArrayAlloca/self_referencing_store_untouched.ll b/test/PointerArrayAlloca/self_referencing_store_untouched.ll
+new file mode 100644
+index 0000000..74793a4
+--- /dev/null
++++ b/test/PointerArrayAlloca/self_referencing_store_untouched.ll
+@@ -0,0 +1,19 @@
++; A store of the element address into its own slot uses that address twice.
++; The pattern is refused: rewriting it would queue one instruction for deletion
++; twice.
++; RUN: clspv-opt %s -o %t.ll --passes=lower-pointer-array-alloca
++; RUN: FileCheck %s < %t.ll
++
++; CHECK: alloca [2 x ptr]
++; CHECK: store ptr %gd, ptr %gd
++
++target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-G1"
++target triple = "spirv32-unknown-vulkan"
++
++define void @test(i32 %which) {
++entry:
++  %planes = alloca [2 x ptr], align 4
++  %gd = getelementptr [2 x ptr], ptr %planes, i32 0, i32 %which
++  store ptr %gd, ptr %gd, align 4
 +  ret void
 +}

--- a/ci/patches/clspv/0001-lower-pointer-array-alloca.patch
+++ b/ci/patches/clspv/0001-lower-pointer-array-alloca.patch
@@ -1,0 +1,458 @@
+diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
+index c458729..93a9ad9 100644
+--- a/lib/CMakeLists.txt
++++ b/lib/CMakeLists.txt
+@@ -67,6 +67,7 @@ add_library(clspv_passes OBJECT
+   ${CMAKE_CURRENT_SOURCE_DIR}/SetImageMetadataPass.cpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/ThreeElementVectorLoweringPass.cpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/LowerAddrSpaceCastPass.cpp
++  ${CMAKE_CURRENT_SOURCE_DIR}/LowerPointerArrayAllocaPass.cpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/LowerPrivatePointerPHIPass.cpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/MultiVersionUBOFunctionsPass.cpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/NativeMathPass.cpp
+diff --git a/lib/Compiler.cpp b/lib/Compiler.cpp
+index e059dfd..38061f3 100644
+--- a/lib/Compiler.cpp
++++ b/lib/Compiler.cpp
+@@ -840,6 +840,11 @@ int RunPassPipeline(llvm::Module &M, llvm::raw_svector_ostream *binaryStream) {
+       pm.addPass(llvm::createModuleToFunctionPassAdaptor(llvm::DCEPass()));
+     }
+ 
++    // Arrays of pointers have no representation in the logical addressing
++    // model. SROA has already removed the ones it could; this removes the rest
++    // so that the producer never has to type a pointer held in memory.
++    pm.addPass(clspv::LowerPointerArrayAllocaPass());
++
+     // This pass needs to run before an interation of
+     // SimplifyPointerBitcastPass/ReplacePointerBitcastPass.
+     pm.addPass(clspv::LowerPrivatePointerPHIPass());
+diff --git a/lib/LowerPointerArrayAllocaPass.cpp b/lib/LowerPointerArrayAllocaPass.cpp
+new file mode 100644
+index 0000000..9ecf425
+--- /dev/null
++++ b/lib/LowerPointerArrayAllocaPass.cpp
+@@ -0,0 +1,262 @@
++// Copyright 2026 The Clspv Authors. All rights reserved.
++//
++// Licensed under the Apache License, Version 2.0 (the "License");
++// you may not use this file except in compliance with the License.
++// You may obtain a copy of the License at
++//
++//     http://www.apache.org/licenses/LICENSE-2.0
++//
++// Unless required by applicable law or agreed to in writing, software
++// distributed under the License is distributed on an "AS IS" BASIS,
++// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++// See the License for the specific language governing permissions and
++// limitations under the License.
++
++#include "llvm/ADT/SmallVector.h"
++#include "llvm/IR/Dominators.h"
++#include "llvm/IR/IRBuilder.h"
++#include "llvm/IR/Instructions.h"
++#include "llvm/IR/Module.h"
++#include "llvm/Transforms/Utils/PromoteMemToReg.h"
++
++#include "LowerPointerArrayAllocaPass.h"
++
++using namespace llvm;
++
++namespace {
++
++// A select chain is linear in the number of elements, so a very large pointer
++// table would trade one unrepresentable construct for a great deal of code. In
++// practice these tables are small (one entry per image plane); refuse to
++// rewrite anything unreasonable and leave it to the producer to report.
++constexpr uint64_t kMaxElements = 64;
++
++// Returns the element index of |gep| if it is a well formed access to the
++// pointer array, i.e. `getelementptr [N x ptr], ptr %alloca, i32 0, idx`.
++// |index_out| is set to the second operand, which may or may not be constant.
++bool isElementGEP(GetElementPtrInst *gep, AllocaInst *alloca,
++                  ArrayType *array_ty, Value **index_out) {
++  if (gep->getPointerOperand() != alloca) {
++    return false;
++  }
++  if (gep->getSourceElementType() != array_ty) {
++    return false;
++  }
++  if (gep->getNumIndices() != 2) {
++    return false;
++  }
++  auto *first = dyn_cast<ConstantInt>(gep->getOperand(1));
++  if (first == nullptr || !first->isZero()) {
++    return false;
++  }
++  *index_out = gep->getOperand(2);
++  return true;
++}
++
++} // namespace
++
++bool clspv::LowerPointerArrayAllocaPass::isSupportedAccessPattern(
++    AllocaInst *alloca, ArrayType *array_ty) const {
++  for (auto *user : alloca->users()) {
++    auto *gep = dyn_cast<GetElementPtrInst>(user);
++    if (gep == nullptr) {
++      // The array itself is loaded, stored, passed to a call or otherwise
++      // escapes; scalarizing would not be sound.
++      return false;
++    }
++    Value *index = nullptr;
++    if (!isElementGEP(gep, alloca, array_ty, &index)) {
++      return false;
++    }
++    if (auto *constant = dyn_cast<ConstantInt>(index)) {
++      if (constant->getValue().uge(array_ty->getNumElements())) {
++        return false;
++      }
++    }
++    // Only whole-element accesses can be redirected to a scalar alloca.
++    for (auto *gep_user : gep->users()) {
++      if (auto *load = dyn_cast<LoadInst>(gep_user)) {
++        if (load->getType() != array_ty->getElementType()) {
++          return false;
++        }
++        if (!load->isSimple()) {
++          return false;
++        }
++      } else if (auto *store = dyn_cast<StoreInst>(gep_user)) {
++        // Storing the element is fine; storing the *address* of the element
++        // elsewhere is not.
++        if (store->getPointerOperand() != gep) {
++          return false;
++        }
++        if (store->getValueOperand()->getType() !=
++            array_ty->getElementType()) {
++          return false;
++        }
++        if (!store->isSimple()) {
++          return false;
++        }
++      } else {
++        return false;
++      }
++    }
++  }
++  return true;
++}
++
++void clspv::LowerPointerArrayAllocaPass::scalarize(
++    AllocaInst *alloca, ArrayType *array_ty,
++    SmallVectorImpl<AllocaInst *> &scalars) {
++  auto *element_ty = array_ty->getElementType();
++  const uint64_t num_elements = array_ty->getNumElements();
++
++  IRBuilder<> entry_builder(alloca);
++  for (uint64_t i = 0; i < num_elements; i++) {
++    auto *scalar = entry_builder.CreateAlloca(
++        element_ty, alloca->getAddressSpace(),
++        /* ArraySize */ nullptr,
++        alloca->getName() + ".elem" + Twine(i));
++    scalar->setAlignment(alloca->getAlign());
++    scalars.push_back(scalar);
++  }
++
++  SmallVector<Instruction *, 16> dead;
++
++  for (auto *user : llvm::make_early_inc_range(alloca->users())) {
++    auto *gep = cast<GetElementPtrInst>(user);
++    Value *index = nullptr;
++    bool ok = isElementGEP(gep, alloca, array_ty, &index);
++    (void)ok;
++    assert(ok && "access pattern changed since it was validated");
++
++    if (auto *constant = dyn_cast<ConstantInt>(index)) {
++      // Constant index: the access simply becomes an access to that scalar.
++      gep->replaceAllUsesWith(scalars[constant->getZExtValue()]);
++      dead.push_back(gep);
++      continue;
++    }
++
++    // Dynamic index: materialise the value with a select chain instead of an
++    // address computation.
++    for (auto *gep_user : llvm::make_early_inc_range(gep->users())) {
++      if (auto *load = dyn_cast<LoadInst>(gep_user)) {
++        IRBuilder<> builder(load);
++        // Start from the last element and fold backwards, so element 0 ends up
++        // as the outermost condition. An out-of-range index is undefined
++        // behaviour in OpenCL C, so using the last element as the fallback is
++        // as good as any other choice.
++        Value *result = builder.CreateLoad(
++            element_ty, scalars[num_elements - 1],
++            load->getName() + ".elem" + Twine(num_elements - 1));
++        for (int64_t i = static_cast<int64_t>(num_elements) - 2; i >= 0; i--) {
++          Value *candidate =
++              builder.CreateLoad(element_ty, scalars[i],
++                                 load->getName() + ".elem" + Twine(i));
++          Value *is_this = builder.CreateICmpEQ(
++              index, ConstantInt::get(index->getType(), i));
++          result = builder.CreateSelect(is_this, candidate, result);
++        }
++        load->replaceAllUsesWith(result);
++        dead.push_back(load);
++      } else {
++        // Validated above: the only other possibility is a store of the
++        // element through this address. Update every slot, keeping the old
++        // value where the index does not match.
++        auto *store = cast<StoreInst>(gep_user);
++        IRBuilder<> builder(store);
++        Value *stored = store->getValueOperand();
++        for (uint64_t i = 0; i < num_elements; i++) {
++          Value *current = builder.CreateLoad(element_ty, scalars[i]);
++          Value *is_this = builder.CreateICmpEQ(
++              index, ConstantInt::get(index->getType(), i));
++          builder.CreateStore(builder.CreateSelect(is_this, stored, current),
++                              scalars[i]);
++        }
++        dead.push_back(store);
++      }
++    }
++    dead.push_back(gep);
++  }
++
++  for (auto *instruction : dead) {
++    instruction->eraseFromParent();
++  }
++  alloca->eraseFromParent();
++}
++
++bool clspv::LowerPointerArrayAllocaPass::runOnFunction(Function &F) {
++  SmallVector<AllocaInst *, 4> candidates;
++  for (auto &BB : F) {
++    for (auto &I : BB) {
++      auto *alloca = dyn_cast<AllocaInst>(&I);
++      if (alloca == nullptr || alloca->isArrayAllocation()) {
++        continue;
++      }
++      auto *array_ty = dyn_cast<ArrayType>(alloca->getAllocatedType());
++      if (array_ty == nullptr || !array_ty->getElementType()->isPointerTy()) {
++        continue;
++      }
++      if (array_ty->getNumElements() == 0 ||
++          array_ty->getNumElements() > kMaxElements) {
++        continue;
++      }
++      candidates.push_back(alloca);
++    }
++  }
++
++  SmallVector<AllocaInst *, 16> to_promote;
++  for (auto *alloca : candidates) {
++    auto *array_ty = cast<ArrayType>(alloca->getAllocatedType());
++    if (!isSupportedAccessPattern(alloca, array_ty)) {
++      continue;
++    }
++    scalarize(alloca, array_ty, to_promote);
++  }
++
++  // Scalar allocas of pointers are just as unrepresentable as arrays of them,
++  // so promote any that are eligible, including ones this pass did not create.
++  for (auto &BB : F) {
++    for (auto &I : BB) {
++      auto *alloca = dyn_cast<AllocaInst>(&I);
++      if (alloca == nullptr || alloca->isArrayAllocation()) {
++        continue;
++      }
++      if (!alloca->getAllocatedType()->isPointerTy()) {
++        continue;
++      }
++      if (llvm::is_contained(to_promote, alloca)) {
++        continue;
++      }
++      to_promote.push_back(alloca);
++    }
++  }
++
++  SmallVector<AllocaInst *, 16> promotable;
++  for (auto *alloca : to_promote) {
++    if (isAllocaPromotable(alloca)) {
++      promotable.push_back(alloca);
++    }
++  }
++  if (promotable.empty()) {
++    return !to_promote.empty();
++  }
++
++  DominatorTree DT(F);
++  PromoteMemToReg(promotable, DT);
++  return true;
++}
++
++PreservedAnalyses
++clspv::LowerPointerArrayAllocaPass::run(Module &M, ModuleAnalysisManager &) {
++  PreservedAnalyses PA;
++  bool changed = false;
++  for (auto &F : M) {
++    if (F.isDeclaration()) {
++      continue;
++    }
++    changed |= runOnFunction(F);
++  }
++  if (!changed) {
++    return PreservedAnalyses::all();
++  }
++  return PA;
++}
+diff --git a/lib/LowerPointerArrayAllocaPass.h b/lib/LowerPointerArrayAllocaPass.h
+new file mode 100644
+index 0000000..9a16863
+--- /dev/null
++++ b/lib/LowerPointerArrayAllocaPass.h
+@@ -0,0 +1,69 @@
++// Copyright 2026 The Clspv Authors. All rights reserved.
++//
++// Licensed under the Apache License, Version 2.0 (the "License");
++// you may not use this file except in compliance with the License.
++// You may obtain a copy of the License at
++//
++//     http://www.apache.org/licenses/LICENSE-2.0
++//
++// Unless required by applicable law or agreed to in writing, software
++// distributed under the License is distributed on an "AS IS" BASIS,
++// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++// See the License for the specific language governing permissions and
++// limitations under the License.
++
++#ifndef _CLSPV_LIB_LOWER_POINTER_ARRAY_ALLOCA_PASS_H
++#define _CLSPV_LIB_LOWER_POINTER_ARRAY_ALLOCA_PASS_H
++
++#include "llvm/IR/Instructions.h"
++#include "llvm/IR/Module.h"
++#include "llvm/IR/PassManager.h"
++
++namespace clspv {
++
++// Lowers allocas of arrays of pointers into individual scalar allocas which
++// are then promoted to SSA values.
++//
++// SPIR-V's logical addressing model has no representation for a pointer stored
++// in memory, so `alloca [N x ptr addrspace(A)]` cannot be given a SPIR-V type
++// at all -- SPIRVProducerPass' getSPIRVType() rejects every pointer type it is
++// handed. LLVM's SROA promotes such an alloca away whenever every index is
++// constant, but it gives up as soon as one access uses a dynamic index, which
++// is exactly what an OpenCL C kernel holding a table of `__global` pointers
++// (an image plane table, say) produces:
++//
++//   __global ushort *planes[6];
++//   ...
++//   value = planes[which][offset];
++//
++// This pass finishes what SROA started. Each array element becomes its own
++// scalar alloca, constant-index accesses are redirected to the matching scalar,
++// and a dynamic-index access becomes a select chain over all the elements.
++// Once no access needs an address computation the scalars are promoted with
++// mem2reg, leaving the pointers as SSA values, selects and phis -- all of which
++// the producer can emit under the VariablePointers capability.
++//
++// Allocas whose access pattern is not understood are left untouched rather than
++// transformed incorrectly.
++struct LowerPointerArrayAllocaPass
++    : llvm::PassInfoMixin<LowerPointerArrayAllocaPass> {
++  llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager &);
++
++private:
++  bool runOnFunction(llvm::Function &F);
++
++  // Returns true when every use of |alloca| is an access this pass knows how to
++  // rewrite: a `getelementptr [N x ptr], ptr %alloca, 0, idx` whose only users
++  // are loads and stores of the element itself.
++  bool isSupportedAccessPattern(llvm::AllocaInst *alloca,
++                                llvm::ArrayType *array_ty) const;
++
++  // Replaces |alloca| with one scalar alloca per element, rewriting all
++  // accesses. Returns the newly created allocas.
++  void scalarize(llvm::AllocaInst *alloca, llvm::ArrayType *array_ty,
++                 llvm::SmallVectorImpl<llvm::AllocaInst *> &scalars);
++};
++
++} // namespace clspv
++
++#endif // _CLSPV_LIB_LOWER_POINTER_ARRAY_ALLOCA_PASS_H
+diff --git a/lib/PassRegistry.def b/lib/PassRegistry.def
+index 59669aa..0c0437d 100644
+--- a/lib/PassRegistry.def
++++ b/lib/PassRegistry.def
+@@ -41,6 +41,7 @@ MODULE_PASS("logical-pointer-to-int", clspv::LogicalPointerToIntPass)
+ MODULE_PASS("long-vector-lowering", clspv::LongVectorLoweringPass)
+ MODULE_PASS("set-image-metadata", clspv::SetImageMetadataPass)
+ MODULE_PASS("lower-addrspacecast", clspv::LowerAddrSpaceCastPass)
++MODULE_PASS("lower-pointer-array-alloca", clspv::LowerPointerArrayAllocaPass)
+ MODULE_PASS("lower-private-pointer-phi", clspv::LowerPrivatePointerPHIPass)
+ MODULE_PASS("multi-version-ubo-functions", clspv::MultiVersionUBOFunctionsPass)
+ MODULE_PASS("native-math", clspv::NativeMathPass)
+diff --git a/lib/Passes.h b/lib/Passes.h
+index 210b874..1226aa8 100644
+--- a/lib/Passes.h
++++ b/lib/Passes.h
+@@ -39,6 +39,7 @@
+ #include "LogicalPointerToIntPass.h"
+ #include "LongVectorLoweringPass.h"
+ #include "LowerAddrSpaceCastPass.h"
++#include "LowerPointerArrayAllocaPass.h"
+ #include "LowerPrivatePointerPHIPass.h"
+ #include "MultiVersionUBOFunctionsPass.h"
+ #include "NativeMathPass.h"
+diff --git a/test/PointerArrayAlloca/dynamic_index_load.ll b/test/PointerArrayAlloca/dynamic_index_load.ll
+new file mode 100644
+index 0000000..aa67027
+--- /dev/null
++++ b/test/PointerArrayAlloca/dynamic_index_load.ll
+@@ -0,0 +1,28 @@
++; RUN: clspv-opt %s -o %t.ll --passes=lower-pointer-array-alloca
++; RUN: FileCheck %s < %t.ll
++
++; CHECK-NOT: alloca
++; CHECK: [[cmp:%[^ ]+]] = icmp eq i32 %which, 0
++; CHECK: [[sel:%[^ ]+]] = select i1 [[cmp]], ptr addrspace(1) %a, ptr addrspace(1) %b
++; CHECK: load i16, ptr addrspace(1) [[sel]], align 2
++
++; An array of global pointers indexed dynamically has no representation in the
++; logical addressing model. SROA leaves it alone because of the dynamic index,
++; so this pass has to scalarize it and select between the elements instead.
++
++target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-G1"
++target triple = "spirv32-unknown-vulkan"
++
++define void @test(ptr addrspace(1) %a, ptr addrspace(1) %b, i32 %which, ptr addrspace(1) %out) {
++entry:
++  %planes = alloca [2 x ptr addrspace(1)], align 4
++  %g0 = getelementptr [2 x ptr addrspace(1)], ptr %planes, i32 0, i32 0
++  store ptr addrspace(1) %a, ptr %g0, align 4
++  %g1 = getelementptr [2 x ptr addrspace(1)], ptr %planes, i32 0, i32 1
++  store ptr addrspace(1) %b, ptr %g1, align 4
++  %gd = getelementptr [2 x ptr addrspace(1)], ptr %planes, i32 0, i32 %which
++  %p = load ptr addrspace(1), ptr %gd, align 4
++  %v = load i16, ptr addrspace(1) %p, align 2
++  store i16 %v, ptr addrspace(1) %out, align 2
++  ret void
++}
+diff --git a/test/PointerArrayAlloca/escaping_array_untouched.ll b/test/PointerArrayAlloca/escaping_array_untouched.ll
+new file mode 100644
+index 0000000..61f6382
+--- /dev/null
++++ b/test/PointerArrayAlloca/escaping_array_untouched.ll
+@@ -0,0 +1,23 @@
++; RUN: clspv-opt %s -o %t.ll --passes=lower-pointer-array-alloca
++; RUN: FileCheck %s < %t.ll
++
++; When the pointer array escapes -- here its address is handed to a call -- the
++; access pattern is not one this pass can rewrite soundly, so it must leave the
++; alloca alone rather than transform it incorrectly.
++
++; CHECK: alloca [2 x ptr addrspace(1)]
++; CHECK: call void @use(ptr %planes)
++
++target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-G1"
++target triple = "spirv32-unknown-vulkan"
++
++declare void @use(ptr)
++
++define void @test(ptr addrspace(1) %a) {
++entry:
++  %planes = alloca [2 x ptr addrspace(1)], align 4
++  %g0 = getelementptr [2 x ptr addrspace(1)], ptr %planes, i32 0, i32 0
++  store ptr addrspace(1) %a, ptr %g0, align 4
++  call void @use(ptr %planes)
++  ret void
++}

--- a/ci/windows/Build-OpenCL.ps1
+++ b/ci/windows/Build-OpenCL.ps1
@@ -3,7 +3,13 @@ param(
     [string]$SourceRoot = "C:\clvk-src",
     [string]$BuildRoot = "C:\clvk-build",
     [string]$ClvkRepository = "https://github.com/winboat-org/clvk-helios.git",
-    [string]$ClvkCommit = "5b16bbba42835d99816d5d1014d08f7a4ea4e1ef"
+    [string]$ClvkCommit = "5b16bbba42835d99816d5d1014d08f7a4ea4e1ef",
+    # Patches applied to the clspv submodule after checkout. clvk-helios carries
+    # clspv as a submodule of upstream google/clspv, so Helios-local compiler
+    # fixes live here as patches until there is enough divergence to justify a
+    # clspv fork. Applied in file-name order; any failure fails the build rather
+    # than silently shipping an unpatched compiler.
+    [string]$ClspvPatchDir = (Join-Path $PSScriptRoot "..\patches\clspv")
 )
 
 Set-StrictMode -Version Latest
@@ -20,6 +26,22 @@ try {
     if ($LASTEXITCODE -ne 0) { throw "Failed to check out clvk $ClvkCommit." }
     & git submodule update --init --recursive
     if ($LASTEXITCODE -ne 0) { throw "Failed to initialize clvk submodules." }
+
+    if (Test-Path -LiteralPath $ClspvPatchDir -PathType Container) {
+        $patches = @(Get-ChildItem -LiteralPath $ClspvPatchDir -Filter "*.patch" -File | Sort-Object Name)
+        foreach ($patch in $patches) {
+            Write-Host "Applying clspv patch $($patch.Name)"
+            Push-Location (Join-Path $SourceRoot "external\clspv")
+            try {
+                & git apply --verbose $patch.FullName
+                if ($LASTEXITCODE -ne 0) { throw "Failed to apply clspv patch $($patch.Name)." }
+            } finally {
+                Pop-Location
+            }
+        }
+        Write-Host "Applied $($patches.Count) clspv patch(es)."
+    }
+
     & python.exe external/clspv/utils/fetch_sources.py --shallow --deps llvm
     if ($LASTEXITCODE -ne 0) { throw "Failed to fetch clvk LLVM sources." }
 } finally {
@@ -58,6 +80,13 @@ if (Test-Path -LiteralPath $vendorPdb -PathType Leaf) {
 }
 Set-Content -LiteralPath (Join-Path $OutputDir "clvk-commit.txt") -Value $ClvkCommit -Encoding ascii
 Set-Content -LiteralPath (Join-Path $OutputDir "clvk-repository.txt") -Value $ClvkRepository -Encoding ascii
+# Record which compiler patches this artifact was built with, so a deployed
+# clvk.dll can be told apart from a stock one without disassembling it.
+$appliedPatches = if (Test-Path -LiteralPath $ClspvPatchDir -PathType Container) {
+    @(Get-ChildItem -LiteralPath $ClspvPatchDir -Filter "*.patch" -File | Sort-Object Name | ForEach-Object { $_.Name })
+} else { @() }
+Set-Content -LiteralPath (Join-Path $OutputDir "clspv-patches.txt") `
+    -Value ($appliedPatches -join "`n") -Encoding ascii
 $licenseRoot = Join-Path $OutputDir "licenses"
 $licenses = [ordered]@{
     "clvk-LICENSE" = Join-Path $SourceRoot "LICENSE"


### PR DESCRIPTION
DaVinci Resolve 21.0.4 crashed when importing a clip. The bundled clspv trapped with a
bare `int 3` inside `SPIRVProducerPass`, taking Resolve down with it; the shipped
`clvk.dll` is built with `CLVK_ENABLE_ASSERTIONS=OFF`, so the `llvm_unreachable` message
is stripped and the failure is mute.

An assertions build names it exactly:

```
Unsupported opaque pointer
UNREACHABLE executed at clspv/lib/SPIRVProducerPass.cpp:1977
inst: %planes = alloca [6 x ptr addrspace(1)], align 4
```

A local array of `__global` pointers — an image plane table. SPIR-V's logical addressing
model cannot represent a pointer held in memory, so `getSPIRVType()` rejects the type
outright. LLVM's SROA normally promotes such an alloca away but gives up once an access
uses a dynamic index, which is exactly Resolve's pattern: constant-index stores, then
`planes[which]` read inside a loop.

## Reproducer

350 bytes, no Blackmagic code:

```c
__kernel void p2(__global uchar *a, __global uchar *b, int which,
                 __global uint *out) {
  __global uchar *planes[2];
  planes[0] = a;
  planes[1] = b;
  out[0] = (uint)planes[which][get_global_id(0)];
}
```

Reproduces on both an assertions build and the shipped `clvk.dll`. A struct-of-pointers
variant with static indexing compiles fine, pinning the trigger to dynamic indexing into
a pointer array.

## Fix

New pass `clspv::LowerPointerArrayAllocaPass`, scheduled before
`AllocateDescriptorsPass`. It scalarizes the array into per-element allocas, turns a
dynamic-index load into a select chain and a dynamic-index store into a conditional
update of every slot, then promotes the scalars with mem2reg. Pointers survive only as
SSA values, selects and phis — all emittable under VariablePointers. Access patterns the
pass does not understand are left untouched rather than transformed incorrectly.

clvk-helios carries clspv as a submodule of upstream google/clspv, so the fix ships as a
patch applied by `Build-OpenCL.ps1` after submodule checkout. Forking clspv can wait
until there is enough divergence to justify it. The applied patch list is recorded in the
artifact as `clspv-patches.txt`.

## Post-review hardening (8be14ec)

A senior review found five confirmed defects, all fixed. The consequential one: the pass
originally ran *after* `AllocateDescriptorsPass`, so a kernel argument whose only use is
a store into the table — Resolve's own shape — made the descriptor allocator assert
before the lowering was reached. Also fixed: an erase-after-free on a self-referencing
store, a silent miscompile from an index type narrower than the element count, unsound
handling of private-pointer arrays, and a dead promotion phase with a live hazard.
Lifetime markers and the folded single-index GEP form are now handled rather than
refused.

## Verification

- upstream clspv suite **3810/3810**, tests grown 2 → 6 including an end-to-end `.cl`
  case that runs `spirv-val`
- all 12 kernels of the captured Resolve program compile, SPIR-V valid
- the full 1 MB capture with Resolve's own options compiles to a 472,380-byte module
  that passes `spirv-val --target-env vulkan1.3`, which also clears the invalid `OpPhi`
  its validator reported
- CI run 31448922583: all six jobs green, so the pass builds under MSVC
- end to end on the VM: `clBuildProgram` returns `CL_SUCCESS` on Resolve's own program
  through the shipped ICD path, and **Resolve now imports clips**

## Known gaps

Refused rather than mislowered, each still hitting the original producer abort: 2-D
pointer arrays, tables over 64 entries, pointer arrays inside structs, and arrays of
`__private` pointers. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)