### PR TITLE
Windows: add WoW64 Vulkan and OpenGL stack

### DIFF
--- a/.github/workflows/windows-stack.yml
+++ b/.github/workflows/windows-stack.yml
@@ -82,7 +82,7 @@ jobs:
           retention-days: 14
 
   mesa:
-    name: Mesa Venus Vulkan and Zink OpenGL
+    name: Mesa Venus Vulkan and Zink OpenGL (x64)
     runs-on: windows-2022
     timeout-minutes: 120
     steps:
@@ -118,6 +118,46 @@ jobs:
         with:
           name: helios-mesa
           path: ${{ runner.temp }}/helios-mesa
+          if-no-files-found: error
+          retention-days: 14
+
+  mesa_x86:
+    name: Mesa Venus Vulkan and Zink OpenGL (WoW64 x86)
+    runs-on: windows-2022
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: false
+          fetch-depth: 1
+      - name: Initialize Mesa fork
+        shell: pwsh
+        run: git submodule update --init icd/mesa
+      - uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884
+        with:
+          msystem: MINGW32
+          update: true
+          install: >-
+            git
+            mingw-w64-i686-gcc
+            mingw-w64-i686-meson
+            mingw-w64-i686-ninja
+            mingw-w64-i686-python
+            mingw-w64-i686-python-mako
+            mingw-w64-i686-python-packaging
+            mingw-w64-i686-python-yaml
+            mingw-w64-i686-pkgconf
+            mingw-w64-i686-vulkan-headers
+            mingw-w64-i686-vulkan-loader
+            bison
+            flex
+      - name: Build WoW64 Mesa runtime
+        shell: msys2 {0}
+        run: bash ./ci/windows/build-mesa.sh "$GITHUB_WORKSPACE" "$RUNNER_TEMP/helios-mesa-x86"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: helios-mesa-x86
+          path: ${{ runner.temp }}/helios-mesa-x86
           if-no-files-found: error
           retention-days: 14
 
@@ -208,7 +248,7 @@ jobs:
 
   package:
     name: Sign and assemble installable bundle
-    needs: [driver, mesa, opencl, loaders, compatibility]
+    needs: [driver, mesa, mesa_x86, opencl, loaders, compatibility]
     runs-on: windows-2022
     timeout-minutes: 30
     permissions:
@@ -226,6 +266,10 @@ jobs:
         with:
           name: helios-mesa
           path: ${{ runner.temp }}/artifacts/mesa
+      - uses: actions/download-artifact@v8
+        with:
+          name: helios-mesa-x86
+          path: ${{ runner.temp }}/artifacts/mesa-x86
       - uses: actions/download-artifact@v8
         with:
           name: helios-opencl
@@ -256,6 +300,7 @@ jobs:
           -RepoRoot $env:GITHUB_WORKSPACE
           -DriverArtifact "$env:RUNNER_TEMP/artifacts/driver"
           -MesaArtifact "$env:RUNNER_TEMP/artifacts/mesa"
+          -MesaX86Artifact "$env:RUNNER_TEMP/artifacts/mesa-x86"
           -OpenClArtifact "$env:RUNNER_TEMP/artifacts/opencl"
           -LoadersArtifact "$env:RUNNER_TEMP/artifacts/loaders"
           -CompatibilityArtifact "$env:RUNNER_TEMP/artifacts/compatibility"

--- a/WINDOWS_CI_PACKAGE.md
+++ b/WINDOWS_CI_PACKAGE.md
@@ -1,8 +1,9 @@
 # Windows CI package
 
 The `Windows graphics and compute bundle` GitHub Actions workflow builds one
-x64 archive that turns a clean Helios Windows 11 guest into a system-wide
-graphics/compute installation.
+x64 Windows archive that turns a clean Helios Windows 11 guest into a
+system-wide graphics/compute installation. It includes x86 Vulkan/OpenGL
+components for WoW64 applications alongside the native x64 stack.
 
 ## What the workflow builds
 
@@ -10,12 +11,12 @@ The jobs are independent so an error points at the actual component:
 
 1. `driver` builds the DXVK static D3D11 core, embeds it in `helios_umd.dll`,
    and builds/packages the Rust WDDM kernel driver.
-2. `mesa` builds the pinned Mesa submodule once with both the Venus Vulkan ICD
-   and the Zink WGL OpenGL ICD enabled.
+2. `mesa` and `mesa_x86` build the pinned Mesa submodule for x64 and x86 with
+   both the Venus Vulkan ICD and the Zink WGL OpenGL ICD enabled.
 3. `opencl` builds pinned CLVK with the clspv online compiler embedded. End-user
    machines therefore do not need `clspv.exe` or `CLVK_CLSPV_PATH`.
-4. `loaders` builds the official Khronos Vulkan and OpenCL loaders plus four
-   native smoke probes.
+4. `loaders` builds the official x64 Vulkan/OpenCL loaders, the x86 Vulkan
+   loader, and architecture-matched smoke probes.
 5. `compatibility` builds and validates the app-local DaVinci Resolve ADL shim.
 6. `package` test-signs the final driver package and compatibility shim, hashes
    every distributed binary,
@@ -58,11 +59,12 @@ the ephemeral certificate.
 
 - installs the Visual C++ x64 runtime and the prebuilt PnP driver package;
 - installs Mesa and CLVK in a versioned directory below `Program Files`;
-- installs official `vulkan-1.dll`/`OpenCL.dll` only when no system loader is
-  present;
+- installs official x64 and x86 `vulkan-1.dll` loaders and the x64 `OpenCL.dll`
+  only when the matching system loader is absent;
 - registers Venus and CLVK through the Khronos machine ICD registries; and
-- registers `libgallium_wgl.dll` as the Microsoft OpenGL ICD on the Helios
-  display adapter key. It does not replace Windows' `opengl32.dll`.
+- registers the x64 and x86 `libgallium_wgl.dll` files as the Microsoft OpenGL
+  ICDs on the Helios display adapter key. It does not replace Windows'
+  `opengl32.dll`.
 
 Original OpenGL registry values and every created path/hash are saved in
 `C:\ProgramData\Helios\install-state.json`. The package refuses to overwrite an
@@ -87,6 +89,7 @@ and WDK. The setup script uses an already installed WDK when available and
 otherwise installs the official 10.0.26100 SDK/WDK packages with winget. A
 self-hosted runner should preinstall those tools if winget is unavailable.
 
-The current bundle is x64-only. A real WoW64 deliverable needs independently
-validated x86 builds of the WDDM UMD, Mesa, CLVK, and both loaders; copying x64
-DLLs into `SysWOW64` is not a valid substitute.
+The bundle supports WoW64 Vulkan and OpenGL using independently built x86 Mesa
+and Vulkan-loader binaries. WoW64 Direct3D and OpenCL still require separately
+built x86 WDDM UMD/DXVK and CLVK/OpenCL-loader components; copying x64 DLLs into
+`SysWOW64` is not a valid substitute.

--- a/ci/windows/Assemble-Package.ps1
+++ b/ci/windows/Assemble-Package.ps1
@@ -2,6 +2,7 @@ param(
     [Parameter(Mandatory)][string]$RepoRoot,
     [Parameter(Mandatory)][string]$DriverArtifact,
     [Parameter(Mandatory)][string]$MesaArtifact,
+    [Parameter(Mandatory)][string]$MesaX86Artifact,
     [Parameter(Mandatory)][string]$OpenClArtifact,
     [Parameter(Mandatory)][string]$LoadersArtifact,
     [Parameter(Mandatory)][string]$CompatibilityArtifact,
@@ -63,6 +64,14 @@ foreach ($dependency in Get-ChildItem -LiteralPath $MesaArtifact -Filter "lib*.d
     if ($dependency.Name -eq "libgallium_wgl.dll") { continue }
     Copy-Required $dependency.FullName (Join-Path $mesaOut $dependency.Name)
 }
+$mesaX86Out = Join-Path $mesaOut "x86"
+foreach ($name in @("vulkan_virtio.dll", "libgallium_wgl.dll")) {
+    Copy-Required (Join-Path $MesaX86Artifact $name) (Join-Path $mesaX86Out $name)
+}
+foreach ($dependency in Get-ChildItem -LiteralPath $MesaX86Artifact -Filter "lib*.dll" -File) {
+    if ($dependency.Name -eq "libgallium_wgl.dll") { continue }
+    Copy-Required $dependency.FullName (Join-Path $mesaX86Out $dependency.Name)
+}
 
 $openClOut = Join-Path $payload "opencl"
 Copy-Required (Join-Path $OpenClArtifact "clvk.dll") (Join-Path $openClOut "clvk.dll")
@@ -72,6 +81,7 @@ if (Test-Path -LiteralPath $clvkPdb -PathType Leaf) { Copy-Required $clvkPdb (Jo
 $loadersOut = Join-Path $payload "loaders"
 Copy-Required (Join-Path $LoadersArtifact "vulkan-1.dll") (Join-Path $loadersOut "vulkan-1.dll")
 Copy-Required (Join-Path $LoadersArtifact "OpenCL.dll") (Join-Path $loadersOut "OpenCL.dll")
+Copy-Required (Join-Path $LoadersArtifact "x86\vulkan-1.dll") (Join-Path $loadersOut "x86\vulkan-1.dll")
 foreach ($probe in @(
     "vulkan-smoke.exe",
     "vulkan-wsi-probe.exe",
@@ -81,6 +91,9 @@ foreach ($probe in @(
     "opencl-gl-sharing-smoke.exe"
 )) {
     Copy-Required (Join-Path $LoadersArtifact "smoke\$probe") (Join-Path $payload "smoke\$probe")
+}
+foreach ($probe in @("vulkan-smoke.exe", "vulkan-wsi-probe.exe", "opengl-smoke.exe")) {
+    Copy-Required (Join-Path $LoadersArtifact "smoke\x86\$probe") (Join-Path $payload "smoke\x86\$probe")
 }
 
 $resolveCompatibilityOut = Join-Path $stagingRoot "compatibility\DaVinci Resolve"
@@ -99,7 +112,7 @@ if (-not $redist) { throw "The Visual C++ x64 redistributable was not found belo
 Copy-Required $redist.FullName (Join-Path $payload "prerequisites\vc_redist.x64.exe")
 
 $licenseOut = Join-Path $stagingRoot "licenses"
-foreach ($artifact in @($DriverArtifact, $MesaArtifact, $OpenClArtifact, $LoadersArtifact, $CompatibilityArtifact)) {
+foreach ($artifact in @($DriverArtifact, $MesaArtifact, $MesaX86Artifact, $OpenClArtifact, $LoadersArtifact, $CompatibilityArtifact)) {
     $artifactLicenses = Join-Path $artifact "licenses"
     if (Test-Path -LiteralPath $artifactLicenses -PathType Container) {
         New-Item -ItemType Directory -Force -Path $licenseOut | Out-Null
@@ -140,11 +153,12 @@ try {
     $signable = @(
         (Join-Path $openClOut "clvk.dll"),
         (Join-Path $loadersOut "vulkan-1.dll"),
+        (Join-Path $loadersOut "x86\vulkan-1.dll"),
         (Join-Path $loadersOut "OpenCL.dll"),
         (Join-Path $resolveCompatibilityOut "atiadlxx.dll")
     )
-    $signable += @(Get-ChildItem -LiteralPath $mesaOut -Filter "*.dll" -File | ForEach-Object FullName)
-    $signable += @(Get-ChildItem -LiteralPath (Join-Path $payload "smoke") -Filter "*.exe" -File | ForEach-Object FullName)
+    $signable += @(Get-ChildItem -LiteralPath $mesaOut -Filter "*.dll" -File -Recurse | ForEach-Object FullName)
+    $signable += @(Get-ChildItem -LiteralPath (Join-Path $payload "smoke") -Filter "*.exe" -File -Recurse | ForEach-Object FullName)
     foreach ($file in $signable) { Invoke-SignTool $signTool $certificate.Thumbprint $file }
 } finally {
     Remove-Item -LiteralPath "Cert:\CurrentUser\My\$($certificate.Thumbprint)" -Force -ErrorAction SilentlyContinue
@@ -166,6 +180,7 @@ $manifest = [ordered]@{
     packageId = $packageId
     version = $Version
     architecture = "x64"
+    applicationArchitectures = @("x64", "x86")
     createdAtUtc = [DateTime]::UtcNow.ToString("o")
     source = [ordered]@{
         helios = $RepositoryCommit
@@ -185,7 +200,7 @@ $manifest = [ordered]@{
     }
     components = [ordered]@{
         driver = [ordered]@{ version = $Version; direct3D = "DXVK embedded WDDM UMD" }
-        mesa = [ordered]@{ vulkan = "Venus"; openGL = "Zink WGL ICD"; vulkanApiVersion = "1.4.352" }
+        mesa = [ordered]@{ vulkan = "Venus"; openGL = "Zink WGL ICD"; architectures = @("x64", "x86"); vulkanApiVersion = "1.4.352" }
         openCl = [ordered]@{ implementation = "CLVK"; onlineCompiler = $true }
         compatibility = [ordered]@{ davinciResolve = "App-local AMD ADL detection shim" }
     }

--- a/ci/windows/Build-KhronosLoaders.ps1
+++ b/ci/windows/Build-KhronosLoaders.ps1
@@ -60,6 +60,20 @@ if ($LASTEXITCODE -ne 0) { throw "Vulkan-Loader build failed." }
 & cmake.exe --install $vkLoaderBuild --config Release
 if ($LASTEXITCODE -ne 0) { throw "Vulkan-Loader install failed." }
 
+$vkLoaderX86Build = Join-Path $BuildRoot "vk-loader-x86"
+$vkLoaderX86Install = Join-Path $BuildRoot "vk-loader-x86-install"
+& cmake.exe -S $vkLoaderSource -B $vkLoaderX86Build -A Win32 `
+    "-DCMAKE_INSTALL_PREFIX=$vkLoaderX86Install" `
+    -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded `
+    "-DVULKAN_HEADERS_INSTALL_DIR=$vkHeadersInstall" `
+    -DBUILD_TESTS=OFF `
+    -DBUILD_WERROR=OFF
+if ($LASTEXITCODE -ne 0) { throw "x86 Vulkan-Loader configure failed." }
+& cmake.exe --build $vkLoaderX86Build --config Release --parallel
+if ($LASTEXITCODE -ne 0) { throw "x86 Vulkan-Loader build failed." }
+& cmake.exe --install $vkLoaderX86Build --config Release
+if ($LASTEXITCODE -ne 0) { throw "x86 Vulkan-Loader install failed." }
+
 $openClBuild = Join-Path $BuildRoot "opencl-loader"
 $openClInstall = Join-Path $BuildRoot "opencl-loader-install"
 & cmake.exe -S $openClLoaderSource -B $openClBuild -A x64 `
@@ -76,15 +90,20 @@ if ($LASTEXITCODE -ne 0) { throw "OpenCL ICD Loader build failed." }
 if ($LASTEXITCODE -ne 0) { throw "OpenCL ICD Loader install failed." }
 
 $vulkanDll = Get-ChildItem -LiteralPath @($vkLoaderInstall, $vkLoaderBuild) -Filter "vulkan-1.dll" -File -Recurse | Select-Object -First 1
+$vulkanX86Dll = Get-ChildItem -LiteralPath @($vkLoaderX86Install, $vkLoaderX86Build) -Filter "vulkan-1.dll" -File -Recurse | Select-Object -First 1
 $openClDll = Get-ChildItem -LiteralPath @($openClInstall, $openClBuild) -Filter "OpenCL.dll" -File -Recurse | Select-Object -First 1
 if (-not $vulkanDll) { throw "Installed Vulkan loader DLL was not found." }
+if (-not $vulkanX86Dll) { throw "Installed x86 Vulkan loader DLL was not found." }
 if (-not $openClDll) { throw "Installed OpenCL loader DLL was not found." }
 Copy-Item -LiteralPath $vulkanDll.FullName -Destination (Join-Path $OutputDir "vulkan-1.dll") -Force
+New-Item -ItemType Directory -Force -Path (Join-Path $OutputDir "x86") | Out-Null
+Copy-Item -LiteralPath $vulkanX86Dll.FullName -Destination (Join-Path $OutputDir "x86\vulkan-1.dll") -Force
 Copy-Item -LiteralPath $openClDll.FullName -Destination (Join-Path $OutputDir "OpenCL.dll") -Force
 
 $vulkanLibrary = Get-ChildItem -LiteralPath @($vkLoaderInstall, $vkLoaderBuild) -Filter "vulkan-1.lib" -File -Recurse | Select-Object -First 1
+$vulkanX86Library = Get-ChildItem -LiteralPath @($vkLoaderX86Install, $vkLoaderX86Build) -Filter "vulkan-1.lib" -File -Recurse | Select-Object -First 1
 $openClLibrary = Get-ChildItem -LiteralPath @($openClInstall, $openClBuild) -Filter "OpenCL.lib" -File -Recurse | Select-Object -First 1
-if (-not $vulkanLibrary -or -not $openClLibrary) { throw "A loader import library required by the smoke probes was not found." }
+if (-not $vulkanLibrary -or -not $vulkanX86Library -or -not $openClLibrary) { throw "A loader import library required by the smoke probes was not found." }
 & (Join-Path $RepoRoot "ci\windows\Build-SmokeTests.ps1") `
     -RepoRoot $RepoRoot `
     -OutputDir (Join-Path $OutputDir "smoke") `
@@ -93,6 +112,14 @@ if (-not $vulkanLibrary -or -not $openClLibrary) { throw "A loader import librar
     -OpenClInclude $openClHeadersSource `
     -OpenClLibrary $openClLibrary.FullName
 if ($LASTEXITCODE -ne 0) { throw "Smoke probe build failed." }
+& (Join-Path $RepoRoot "ci\windows\Build-SmokeTests.ps1") `
+    -RepoRoot $RepoRoot `
+    -OutputDir (Join-Path $OutputDir "smoke\x86") `
+    -VulkanInclude (Join-Path $vkHeadersInstall "include") `
+    -VulkanLibrary $vulkanX86Library.FullName `
+    -Architecture x86 `
+    -GraphicsOnly
+if ($LASTEXITCODE -ne 0) { throw "x86 graphics smoke-probe build failed." }
 
 $pins = [ordered]@{
     vulkanLoader = $VulkanLoaderCommit

--- a/ci/windows/Build-SmokeTests.ps1
+++ b/ci/windows/Build-SmokeTests.ps1
@@ -3,14 +3,16 @@ param(
     [Parameter(Mandatory)][string]$OutputDir,
     [Parameter(Mandatory)][string]$VulkanInclude,
     [Parameter(Mandatory)][string]$VulkanLibrary,
-    [Parameter(Mandatory)][string]$OpenClInclude,
-    [Parameter(Mandatory)][string]$OpenClLibrary
+    [string]$OpenClInclude,
+    [string]$OpenClLibrary,
+    [ValidateSet("x64", "x86")][string]$Architecture = "x64",
+    [switch]$GraphicsOnly
 )
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 . (Join-Path $PSScriptRoot "Initialize-HeliosBuild.ps1")
-Import-VisualStudioEnvironment
+Import-VisualStudioEnvironment -Architecture $Architecture
 Assert-Command "cl.exe" | Out-Null
 New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
 $source = Join-Path $RepoRoot "packaging\windows\probes"
@@ -23,10 +25,14 @@ if ($LASTEXITCODE -ne 0) { throw "Vulkan smoke probe compilation failed." }
     "/Fe:$(Join-Path $OutputDir 'vulkan-wsi-probe.exe')" `
     /link $VulkanLibrary user32.lib gdi32.lib
 if ($LASTEXITCODE -ne 0) { throw "Vulkan WSI probe compilation failed." }
-& cl.exe /nologo /O2 /W4 /MT /EHsc (Join-Path $source "d3d11-smoke.cpp") "/Fe:$(Join-Path $OutputDir 'd3d11-smoke.exe')" /link d3d11.lib dxgi.lib
-if ($LASTEXITCODE -ne 0) { throw "D3D11 smoke probe compilation failed." }
 & cl.exe /nologo /O2 /W4 /MT (Join-Path $source "opengl-smoke.c") "/Fe:$(Join-Path $OutputDir 'opengl-smoke.exe')" /link opengl32.lib gdi32.lib user32.lib
 if ($LASTEXITCODE -ne 0) { throw "OpenGL smoke probe compilation failed." }
+if ($GraphicsOnly) { return }
+if (-not $OpenClInclude -or -not $OpenClLibrary) {
+    throw "OpenCL include and library paths are required for the full smoke-probe set."
+}
+& cl.exe /nologo /O2 /W4 /MT /EHsc (Join-Path $source "d3d11-smoke.cpp") "/Fe:$(Join-Path $OutputDir 'd3d11-smoke.exe')" /link d3d11.lib dxgi.lib
+if ($LASTEXITCODE -ne 0) { throw "D3D11 smoke probe compilation failed." }
 & cl.exe /nologo /O2 /W4 /MT (Join-Path $source "opencl-smoke.c") "/I$OpenClInclude" "/Fe:$(Join-Path $OutputDir 'opencl-smoke.exe')" /link $OpenClLibrary
 if ($LASTEXITCODE -ne 0) { throw "OpenCL smoke probe compilation failed." }
 & cl.exe /nologo /O2 /W4 /MT /EHsc `

--- a/ci/windows/Initialize-HeliosBuild.ps1
+++ b/ci/windows/Initialize-HeliosBuild.ps1
@@ -7,7 +7,9 @@ function ConvertTo-WindowsKitVersion([Parameter(Mandatory)][string]$Value) {
     return [version]"0.0"
 }
 
-function Import-VisualStudioEnvironment {
+function Import-VisualStudioEnvironment(
+    [ValidateSet("x64", "x86")][string]$Architecture = "x64"
+) {
     $vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
     if (-not (Test-Path -LiteralPath $vswhere -PathType Leaf)) {
         throw "vswhere.exe was not found; Visual Studio 2022 with C++ tools is required."
@@ -15,11 +17,11 @@ function Import-VisualStudioEnvironment {
 
     $installation = (& $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath).Trim()
     if (-not $installation) {
-        throw "Visual Studio 2022 with the x64 C++ toolchain was not found."
+        throw "Visual Studio 2022 with the x86/x64 C++ toolchain was not found."
     }
 
     $devCmd = Join-Path $installation "Common7\Tools\VsDevCmd.bat"
-    $environment = & cmd.exe /s /c "`"$devCmd`" -no_logo -arch=x64 -host_arch=x64 && set"
+    $environment = & cmd.exe /s /c "`"$devCmd`" -no_logo -arch=$Architecture -host_arch=x64 && set"
     if ($LASTEXITCODE -ne 0) {
         throw "VsDevCmd.bat failed with exit code $LASTEXITCODE."
     }

--- a/ci/windows/build-mesa.sh
+++ b/ci/windows/build-mesa.sh
@@ -6,18 +6,33 @@ set -euo pipefail
 # invalid `-includeD:A:/...` form before Meson sees it.
 export MSYS2_ARG_CONV_EXCL='*'
 
-repo_root="$(cygpath -m "${1:?usage: build-mesa.sh REPO_ROOT OUTPUT_DIR [BUILD_DIR]}")"
-output_dir="$(cygpath -m "${2:?usage: build-mesa.sh REPO_ROOT OUTPUT_DIR [BUILD_DIR]}")"
+repo_root="$(cygpath -m "${1:?usage: build-mesa.sh REPO_ROOT OUTPUT_DIR [BUILD_DIR] [--clean|--reuse]}")"
+output_dir="$(cygpath -m "${2:?usage: build-mesa.sh REPO_ROOT OUTPUT_DIR [BUILD_DIR] [--clean|--reuse]}")"
 build_dir="$(cygpath -m "${3:-C:/helios-mesa-build}")"
+build_mode="${4:---clean}"
 
 mesa_src="${repo_root}/icd/mesa"
 native_file="${repo_root}/ci/windows/mingw-native.ini"
 compat_header="${repo_root}/icd/win-build/helios_win_compat.h"
 
-rm -rf "${build_dir}"
+setup_mode=()
+case "${build_mode}" in
+  --clean)
+    rm -rf "${build_dir}"
+    ;;
+  --reuse)
+    if [[ -f "${build_dir}/build.ninja" ]]; then
+      setup_mode+=(--reconfigure)
+    fi
+    ;;
+  *)
+    printf 'Unknown build mode: %s (expected --clean or --reuse)\n' "${build_mode}" >&2
+    exit 2
+    ;;
+esac
 mkdir -p "${output_dir}"
 
-meson setup "${build_dir}" "${mesa_src}" \
+meson setup "${setup_mode[@]}" "${build_dir}" "${mesa_src}" \
   --native-file "${native_file}" \
   "-Dc_args=-include${compat_header}" \
   -Dvulkan-drivers=virtio \

--- a/packaging/windows/Install-Helios.ps1
+++ b/packaging/windows/Install-Helios.ps1
@@ -164,14 +164,20 @@ if ($activeInfBeforeInstall -and (Test-HeliosViogpudoDriver $activeInfBeforeInst
 
 $classKey = ""
 $vulkanRegistry = "HKLM:\SOFTWARE\Khronos\Vulkan\Drivers"
+$vulkanRegistryX86 = "HKLM:\SOFTWARE\WOW6432Node\Khronos\Vulkan\Drivers"
 $openClRegistry = "HKLM:\SOFTWARE\Khronos\OpenCL\Vendors"
 $vulkanManifestPath = Join-Path $runtimeRoot "mesa\helios_vulkan.json"
+$vulkanManifestX86Path = Join-Path $runtimeRoot "mesa\x86\helios_vulkan.json"
 $clvkPath = Join-Path $runtimeRoot "opencl\clvk.dll"
 $wglPath = Join-Path $runtimeRoot "mesa\libgallium_wgl.dll"
+$wglX86Path = Join-Path $runtimeRoot "mesa\x86\libgallium_wgl.dll"
 $previousOpenGL = [ordered]@{
     OpenGLDriverName = [ordered]@{ exists = $false; kind = $null; value = $null }
     OpenGLVersion = [ordered]@{ exists = $false; kind = $null; value = $null }
     OpenGLFlags = [ordered]@{ exists = $false; kind = $null; value = $null }
+    OpenGLDriverNameWow = [ordered]@{ exists = $false; kind = $null; value = $null }
+    OpenGLVersionWow = [ordered]@{ exists = $false; kind = $null; value = $null }
+    OpenGLFlagsWow = [ordered]@{ exists = $false; kind = $null; value = $null }
 }
 
 $state = [ordered]@{
@@ -185,10 +191,13 @@ $state = [ordered]@{
     activeInf = ""
     signingCertificateThumbprint = ""
     vulkanManifest = $vulkanManifestPath
+    vulkanManifestX86 = $vulkanManifestX86Path
     openClVendor = $clvkPath
     installedVulkanLoader = $false
+    installedVulkanLoaderX86 = $false
     installedOpenClLoader = $false
     systemVulkanLoaderHash = ""
+    systemVulkanLoaderX86Hash = ""
     systemOpenClLoaderHash = ""
     previousOpenGL = $previousOpenGL
     replacedViogpudo = $replacedViogpudo
@@ -284,6 +293,12 @@ if (-not (Test-Path -LiteralPath $systemVulkanLoader -PathType Leaf)) {
     $state.installedVulkanLoader = $true
     $state.systemVulkanLoaderHash = Get-HeliosSha256 $systemVulkanLoader
 }
+$systemVulkanLoaderX86 = Join-Path $env:windir "SysWOW64\vulkan-1.dll"
+if (-not (Test-Path -LiteralPath $systemVulkanLoaderX86 -PathType Leaf)) {
+    Copy-Item -LiteralPath (Join-Path $runtimeRoot "loaders\x86\vulkan-1.dll") -Destination $systemVulkanLoaderX86 -Force
+    $state.installedVulkanLoaderX86 = $true
+    $state.systemVulkanLoaderX86Hash = Get-HeliosSha256 $systemVulkanLoaderX86
+}
 $systemOpenClLoader = Join-Path $env:windir "System32\OpenCL.dll"
 if (-not (Test-Path -LiteralPath $systemOpenClLoader -PathType Leaf)) {
     Copy-Item -LiteralPath (Join-Path $runtimeRoot "loaders\OpenCL.dll") -Destination $systemOpenClLoader -Force
@@ -312,6 +327,9 @@ $state.previousOpenGL = [ordered]@{
     OpenGLDriverName = Get-HeliosRegistrySnapshot $classKey "OpenGLDriverName"
     OpenGLVersion = Get-HeliosRegistrySnapshot $classKey "OpenGLVersion"
     OpenGLFlags = Get-HeliosRegistrySnapshot $classKey "OpenGLFlags"
+    OpenGLDriverNameWow = Get-HeliosRegistrySnapshot $classKey "OpenGLDriverNameWow"
+    OpenGLVersionWow = Get-HeliosRegistrySnapshot $classKey "OpenGLVersionWow"
+    OpenGLFlagsWow = Get-HeliosRegistrySnapshot $classKey "OpenGLFlagsWow"
 }
 $state.activeInf = $activeInf
 Write-HeliosJson $state $statePath
@@ -329,9 +347,25 @@ Write-HeliosJson $vulkanJson $vulkanManifestPath -Encoding ASCII
 New-Item -Path $vulkanRegistry -Force | Out-Null
 New-ItemProperty -LiteralPath $vulkanRegistry -Name $vulkanManifestPath -Value 0 -PropertyType DWord -Force | Out-Null
 
+$vulkanX86Dll = Join-Path $runtimeRoot "mesa\x86\vulkan_virtio.dll"
+$vulkanX86Json = [ordered]@{
+    file_format_version = "1.0.1"
+    ICD = [ordered]@{
+        library_path = ($vulkanX86Dll -replace "\\", "/")
+        library_arch = "32"
+        api_version = [string]$manifest.components.mesa.vulkanApiVersion
+    }
+}
+Write-HeliosJson $vulkanX86Json $vulkanManifestX86Path -Encoding ASCII
+New-Item -Path $vulkanRegistryX86 -Force | Out-Null
+New-ItemProperty -LiteralPath $vulkanRegistryX86 -Name $vulkanManifestX86Path -Value 0 -PropertyType DWord -Force | Out-Null
+
 New-ItemProperty -LiteralPath $classKey -Name "OpenGLDriverName" -Value $wglPath -PropertyType String -Force | Out-Null
 New-ItemProperty -LiteralPath $classKey -Name "OpenGLVersion" -Value 2 -PropertyType DWord -Force | Out-Null
 New-ItemProperty -LiteralPath $classKey -Name "OpenGLFlags" -Value 1 -PropertyType DWord -Force | Out-Null
+New-ItemProperty -LiteralPath $classKey -Name "OpenGLDriverNameWow" -Value $wglX86Path -PropertyType String -Force | Out-Null
+New-ItemProperty -LiteralPath $classKey -Name "OpenGLVersionWow" -Value 2 -PropertyType DWord -Force | Out-Null
+New-ItemProperty -LiteralPath $classKey -Name "OpenGLFlagsWow" -Value 1 -PropertyType DWord -Force | Out-Null
 
 New-Item -Path $openClRegistry -Force | Out-Null
 New-ItemProperty -LiteralPath $openClRegistry -Name $clvkPath -Value 0 -PropertyType DWord -Force | Out-Null
@@ -342,7 +376,7 @@ Copy-Item -LiteralPath (Join-Path $bundleRoot "Verify-Helios.ps1") -Destination 
 Write-HeliosJson $state $statePath
 
 Write-Host ""
-Write-Host "Helios $($manifest.version) is installed system-wide for x64 applications."
+Write-Host "Helios $($manifest.version) is installed system-wide with x64 and WoW64 OpenGL/Vulkan support."
 if ($RunSmokeTests) {
     & (Join-Path $stateRoot "Verify-Helios.ps1") -RunSmokeTests
 } else {

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -1,11 +1,13 @@
-# Helios Windows x64 bundle
+# Helios Windows x64 bundle with WoW64 OpenGL/Vulkan
 
-This archive installs the Helios WDDM driver and its x64 user-mode graphics and
-compute stack:
+This archive installs the Helios WDDM driver, its x64 user-mode graphics and
+compute stack, and the 32-bit Vulkan/OpenGL components needed by WoW64 games:
 
 - Direct3D 11 through the DXVK core embedded in `helios_umd.dll`
 - Vulkan through Mesa Venus (`vulkan_virtio.dll`)
 - desktop OpenGL through Mesa Zink's Microsoft WGL ICD
+- 32-bit Vulkan through a separately built x86 Mesa Venus ICD
+- 32-bit desktop OpenGL through a separately built x86 Zink WGL ICD
 - OpenCL through CLVK with its clspv compiler embedded
 - official Khronos Vulkan and OpenCL loaders when Windows has no loader yet
 - the Microsoft Visual C++ x64 runtime required by the WDDM/DXVK UMD
@@ -90,8 +92,10 @@ The shared Microsoft Visual C++ runtime is also left installed.
 
 ## Current limits
 
-- This package is x64-only. Native 32-bit applications need separately built
-  x86 UMD, Mesa, CLVK, and loader binaries.
+- Native 32-bit Vulkan and OpenGL applications are supported through the x86
+  Vulkan loader, Mesa Venus ICD, and Zink WGL ICD included in the bundle.
+  Native 32-bit Direct3D and OpenCL applications remain unsupported; the DXVK
+  WDDM UMD and CLVK runtime are still x64-only.
 - The QEMU Helios/Venus protocol changes quickly. Build the host QEMU/render
   side from a compatible source revision recorded in `manifest.json`.
 - CI uses an ephemeral public test certificate whose private key is destroyed

--- a/packaging/windows/Uninstall-Helios.ps1
+++ b/packaging/windows/Uninstall-Helios.ps1
@@ -25,6 +25,10 @@ $vulkanRegistry = "HKLM:\SOFTWARE\Khronos\Vulkan\Drivers"
 if (Test-Path -LiteralPath $vulkanRegistry) {
     Remove-ItemProperty -LiteralPath $vulkanRegistry -Name ([string]$state.vulkanManifest) -ErrorAction SilentlyContinue
 }
+$vulkanRegistryX86 = "HKLM:\SOFTWARE\WOW6432Node\Khronos\Vulkan\Drivers"
+if (Test-Path -LiteralPath $vulkanRegistryX86) {
+    Remove-ItemProperty -LiteralPath $vulkanRegistryX86 -Name ([string]$state.vulkanManifestX86) -ErrorAction SilentlyContinue
+}
 $openClRegistry = "HKLM:\SOFTWARE\Khronos\OpenCL\Vendors"
 if (Test-Path -LiteralPath $openClRegistry) {
     Remove-ItemProperty -LiteralPath $openClRegistry -Name ([string]$state.openClVendor) -ErrorAction SilentlyContinue
@@ -35,6 +39,9 @@ if ($classKey -and (Test-Path -LiteralPath $classKey)) {
     Restore-HeliosRegistrySnapshot $classKey "OpenGLDriverName" $state.previousOpenGL.OpenGLDriverName
     Restore-HeliosRegistrySnapshot $classKey "OpenGLVersion" $state.previousOpenGL.OpenGLVersion
     Restore-HeliosRegistrySnapshot $classKey "OpenGLFlags" $state.previousOpenGL.OpenGLFlags
+    Restore-HeliosRegistrySnapshot $classKey "OpenGLDriverNameWow" $state.previousOpenGL.OpenGLDriverNameWow
+    Restore-HeliosRegistrySnapshot $classKey "OpenGLVersionWow" $state.previousOpenGL.OpenGLVersionWow
+    Restore-HeliosRegistrySnapshot $classKey "OpenGLFlagsWow" $state.previousOpenGL.OpenGLFlagsWow
 }
 
 # If a VM configuration change moved the adapter after installation, remove a
@@ -48,6 +55,13 @@ try {
         $currentWgl = (Get-Item -LiteralPath $currentClassKey).GetValue("OpenGLDriverName", $null)
         if ($currentWgl -and ([string]$currentWgl -ieq $expectedWgl)) {
             foreach ($name in @("OpenGLDriverName", "OpenGLVersion", "OpenGLFlags")) {
+                Remove-ItemProperty -LiteralPath $currentClassKey -Name $name -ErrorAction SilentlyContinue
+            }
+        }
+        $expectedWglX86 = Join-Path ([string]$state.installRoot) "runtime\mesa\x86\libgallium_wgl.dll"
+        $currentWglX86 = (Get-Item -LiteralPath $currentClassKey).GetValue("OpenGLDriverNameWow", $null)
+        if ($currentWglX86 -and ([string]$currentWglX86 -ieq $expectedWglX86)) {
+            foreach ($name in @("OpenGLDriverNameWow", "OpenGLVersionWow", "OpenGLFlagsWow")) {
                 Remove-ItemProperty -LiteralPath $currentClassKey -Name $name -ErrorAction SilentlyContinue
             }
         }
@@ -77,6 +91,11 @@ if ($RemoveKhronosLoaders) {
             installed = [bool]$state.installedVulkanLoader
             path = Join-Path $env:windir "System32\vulkan-1.dll"
             hash = [string]$state.systemVulkanLoaderHash
+        },
+        [ordered]@{
+            installed = [bool]$state.installedVulkanLoaderX86
+            path = Join-Path $env:windir "SysWOW64\vulkan-1.dll"
+            hash = [string]$state.systemVulkanLoaderX86Hash
         },
         [ordered]@{
             installed = [bool]$state.installedOpenClLoader

--- a/packaging/windows/Verify-Helios.ps1
+++ b/packaging/windows/Verify-Helios.ps1
@@ -56,10 +56,21 @@ if ($null -eq $vulkanValue -or [int]$vulkanValue -ne 0) {
     $failures.Add("The Vulkan ICD manifest is not enabled in the machine registry.")
 } else { Write-Host "Vulkan: registered $($state.vulkanManifest)" }
 
+$vulkanRegistryX86 = "HKLM:\SOFTWARE\WOW6432Node\Khronos\Vulkan\Drivers"
+$vulkanX86Value = if (Test-Path -LiteralPath $vulkanRegistryX86) { (Get-Item -LiteralPath $vulkanRegistryX86).GetValue([string]$state.vulkanManifestX86, $null) } else { $null }
+if ($null -eq $vulkanX86Value -or [int]$vulkanX86Value -ne 0) {
+    $failures.Add("The x86 Vulkan ICD manifest is not enabled in the WoW64 registry.")
+} else { Write-Host "Vulkan x86: registered $($state.vulkanManifestX86)" }
+
 $openGlDriver = if ($classKey -and (Test-Path -LiteralPath $classKey)) { (Get-Item -LiteralPath $classKey).GetValue("OpenGLDriverName", $null) } else { $null }
 if (-not $openGlDriver -or ([string]$openGlDriver -ine (Join-Path ([string]$state.installRoot) "runtime\mesa\libgallium_wgl.dll"))) {
     $failures.Add("The Helios OpenGL ICD is not registered on the display adapter.")
 } else { Write-Host "OpenGL: registered $openGlDriver" }
+
+$openGlDriverX86 = if ($classKey -and (Test-Path -LiteralPath $classKey)) { (Get-Item -LiteralPath $classKey).GetValue("OpenGLDriverNameWow", $null) } else { $null }
+if (-not $openGlDriverX86 -or ([string]$openGlDriverX86 -ine (Join-Path ([string]$state.installRoot) "runtime\mesa\x86\libgallium_wgl.dll"))) {
+    $failures.Add("The Helios x86 OpenGL ICD is not registered on the display adapter.")
+} else { Write-Host "OpenGL x86: registered $openGlDriverX86" }
 
 $openClRegistry = "HKLM:\SOFTWARE\Khronos\OpenCL\Vendors"
 $openClValue = if (Test-Path -LiteralPath $openClRegistry) { (Get-Item -LiteralPath $openClRegistry).GetValue([string]$state.openClVendor, $null) } else { $null }
@@ -83,7 +94,10 @@ if ($RunSmokeTests) {
             name = "Mixed OpenGL/D3D11 context compatibility"
             exe = "opencl-gl-sharing-smoke.exe"
             arguments = @("rgba16f", "d3d11-context")
-        }
+        },
+        [ordered]@{ name = "Vulkan x86"; exe = "x86\vulkan-smoke.exe"; arguments = @() },
+        [ordered]@{ name = "Vulkan WSI x86"; exe = "x86\vulkan-wsi-probe.exe"; arguments = @() },
+        [ordered]@{ name = "OpenGL x86"; exe = "x86\opengl-smoke.exe"; arguments = @() }
     )
     foreach ($test in $tests) {
         $executable = Join-Path $smokeRoot $test.exe
@@ -102,4 +116,4 @@ if ($failures.Count -gt 0) {
     foreach ($failure in $failures) { Write-Error $failure -ErrorAction Continue }
     throw "Helios verification failed with $($failures.Count) problem(s)."
 }
-Write-Host "Helios Vulkan, Direct3D 11, OpenGL, and OpenCL registrations are healthy."
+Write-Host "Helios x64/WoW64 Vulkan and OpenGL, Direct3D 11, and OpenCL registrations are healthy."


### PR DESCRIPTION
## Summary

- build and package independent x86 Mesa Venus/Zink artifacts
- build and stage an x86 Vulkan loader and x86 graphics smoke probes
- install, verify, and roll back WoW64 Vulkan/WGL registration
- preserve the existing x64 KMD, Direct3D, OpenCL, and native graphics stack

## Validation

- Cave Story+ (PE32) rendered through x86 Zink -> x86 Venus -> existing x64 Helios KMD for 30 seconds
- x86 Vulkan and OpenGL probes reached the host RADV device after reboot
- matching x64 Vulkan/OpenGL probes passed afterward
- complete mixed-architecture package assembled, test-signed, and passed all manifest hashes
- Windows PowerShell AST parsing, workflow YAML parsing, and Bash syntax checks passed
- isolated warm x86 Mesa restage completed in 33 seconds without rebuilding CLVK or the KMD

Mesa dependency: winboat-org/mesa-helios@1712d20735b0feff76cdff678345e520e56086a9