### PR TITLE
umd: convert RGB10 fullscreen presents for scanout

### DIFF
--- a/INVESTIGATIONS/exit8-exclusive-fullscreen-rgb10.md
+++ b/INVESTIGATIONS/exit8-exclusive-fullscreen-rgb10.md
@@ -1,0 +1,176 @@
+# The Exit 8: psychedelic output in exclusive fullscreen
+
+Date: 2026-08-13
+Status: Resolved and manually validated
+
+## Symptom
+
+The Exit 8 renders correctly in windowed and borderless modes. In exclusive
+fullscreen at 1280x800, the geometry remains correct but the output becomes
+strongly posterized with neon colors. The artifact is visible in the QEMU/VNC
+output and is stable from frame to frame.
+
+## Diagnosis
+
+This is a pixel-format identity failure, not a shader, gamma, compression, or
+game-rendering failure.
+
+The game produces a `DXGI_FORMAT_R10G10B10A2_UNORM` surface (DXGI value 24).
+Its packed 10:10:10:2 words reach the fullscreen scanout unchanged, while the
+KMD and QEMU describe that scanout as an 8:8:8:8 AR24 surface (the live KMD
+value is DXGI 87, `B8G8R8A8_UNORM`). QEMU consequently treats the first three
+bytes of each packed 10-bit pixel as ordinary color bytes. That bytewise
+reinterpretation is the psychedelic image.
+
+The end-to-end defect is proven. A traced reproduction identifies the transfer
+as DXGI's cross-format fullscreen blit from Vulkan format 64
+(`A2B10G10R10_UNORM_PACK32`) to Vulkan format 37 (`R8G8B8A8_UNORM`). The old
+UMD implemented this with D3D11 `CopySubresourceRegion`; DXVK correctly treated
+the equal-sized color texels as copy-compatible and emitted a raw image copy.
+The KMD cannot repair the values after those packed bits have entered an
+8-bit-labeled fullscreen primary.
+
+## Paired-capture oracle
+
+Two captures of the same paused frame localize the fault:
+
+- `Graphics.CopyFromScreen` inside the guest is clean.
+- A raw VNC capture from QEMU is psychedelic.
+- Both images are 1280x800 and have identical geometry.
+
+The session artifacts are `tmp/screen_copy.png` and
+`tmp/exit8-host-vnc.png`. Comparing the same coordinates gives an exact packed
+pixel signature:
+
+| coordinate | clean guest RGB | quantized 10-bit RGB | packed RGB10A2 word | host RGB |
+| --- | --- | --- | --- | --- |
+| (0, 349) | (232, 232, 232) | (931, 931, 931) | `0xfa3e8fa3` | (163, 143, 62) |
+| (739, 4) | (170, 170, 170) | (682, 682, 682) | `0xeaaaaaaa` | (170, 170, 170) |
+| (636, 334) | (127, 127, 127) | (509, 509, 509) | `0xdfd7f5fd` | (253, 245, 215) |
+| (740, 441) | (64, 64, 64) | (257, 257, 257) | `0xd0140501` | (1, 5, 20) |
+
+For example, `0xfa3e8fa3` is stored little-endian as `a3 8f 3e fa`.
+Interpreting those bytes as an 8-bit RGB pixel produces exactly
+`(163, 143, 62)`, the host capture. Across the asynchronous full-frame pair,
+87,267 pixels match this transformation exactly; temporal and capture-time
+differences account for the rest.
+
+## Live format evidence
+
+The Exit 8 UMD log records the fullscreen buffers as format 24:
+
+```text
+DDI create_resource(tex2d): 1280x800 fmt=24 ...
+DDI allocate_wddm_resource ... 1280x800 fmt=24 ...
+CreateDdiScanoutTexture2D REFUSED: fmt=24 is not a 32bpp scan-out format
+scanout-snapshot: ring slot 0 create FAILED 1280x800 fmt=24
+DXGI Present: #0 src=0x40003040 ... copied=false flags=0x1
+```
+
+The current KMD diagnostics instead describe the active direct-flip ring as
+8-bit BGRA:
+
+```text
+PBsrc=37  PBsFmt=87  PBsPch=5120  PBsSz=4587520  PBsDir=1
+ScRid=37  ScDir=1    ScPch=5120   ScCpy=2
+VpFlip=42561  VpMmio=42561  VpDmaF=0  SnSub=0
+```
+
+QEMU receives the same surface as DRM fourcc `0x34325241`, or `AR24`, and
+successfully imports it as a 1280x800 OPTIMAL DMA-BUF. The transport and image
+shape are therefore healthy; the declared format is wrong for the payload.
+
+## Code-path findings
+
+The existing KMD conversion machinery is capable of handling this format:
+
+- `PresentPixelFormat::from_dxgi(24)` maps to Vulkan
+  `A2B10G10R10_UNORM_PACK32` in `kmd_render/src/virtio/venus/present.rs`.
+- The scanout/present copy code compares the exact source and destination
+  Vulkan formats and uses an image blit for numeric conversion when they
+  differ.
+- It is bypassed here because the allocation reaching the direct-flip scanout
+  path is already recorded as DXGI 87.
+
+The format was lost in the UMD handoff because:
+
+- `ScanoutFormat::from_dxgi` and the direct-scanout creation gates accept only
+  DXGI 28, 87, and 88. The format-24 snapshot is refused even though it is four
+  bytes per pixel.
+- The former `dxgi_blt` implementation always called
+  `CopySubresourceRegion`, did not branch on conversion flags, and did not
+  reject different source/destination formats.
+- The former `dxgi_blt1` explicitly returned `DXGI_ERROR_UNSUPPORTED` for
+  `BLT_CONVERT`; its non-convert arm was also a raw `CopySubresourceRegion`.
+- `rotate_resource_backings` swaps DXVK image storages and layouts without a
+  format-compatibility check. The Rust allocation/private records rotate in
+  lockstep, but a mixed-format runtime handoff has no fail-closed guard.
+- The live Present path reports `copied=false`, while rotation runs every
+  frame. The log also shows both format-24 game buffers and format-28/87
+  fullscreen primary/proxy buffers at the same 1280x800 geometry.
+
+These paths explain how a four-byte-per-pixel copy can preserve every packed
+10-bit bit while changing only the metadata used by scanout.
+
+## Implemented correction
+
+The correction preserves DXGI 24 until an explicit numeric conversion to the
+canonical 8-bit scanout format has completed:
+
+1. `dxgi_blt` and `dxgi_blt1` classify known unequal formats as numeric
+   conversions. Same-format operations retain the ordinary copy path.
+2. `DxvkContext::copyImageConverted` creates views in each image's native
+   format and calls the Vulkan numeric blit path with nearest filtering.
+3. Format-24 snapshot rings allocate format-28 slots and run the same numeric
+   conversion before publication. Format 24 remains outside the AR24 direct
+   scanout whitelist; it is accepted only as a conversion source.
+4. `rotate_resource_backings` refuses mixed format, type, extent, sample count,
+   mip count, layer count, or array size before changing any backing identity.
+
+An intermediate implementation forced DXVK's private `copyImageFb` helper. A
+live test correctly produced black rather than psychedelic output. Diagnostics
+showed why: `copyImageFb` emulates *copy* semantics by creating both color
+views in the destination format. The exported RGB10 WDDM image cannot be
+relocated to add an RGBA8 reinterpretation view, so `ensureImageCompatibility`
+refused the operation and left the new destination untouched. This was not a
+KMD/QEMU transport failure: the new game process had queued the conversion,
+all Presents succeeded, and a guest GDI capture remained correct, while raw
+QEMU/VNC was all black. Native-format blit views remove that invalid relocation
+and provide the required value conversion.
+
+A future true 10-bit direct-scanout path is possible only if the exact 10-bit
+DRM fourcc and Vulkan format are carried through KMD, QEMU, readback, EGL/VNC,
+and capture. Advertising the current AR24 contract for packed 10-bit memory is
+not such a path.
+
+## Live validation
+
+Revision 3 was built as a complete signed driver package and deployed as a
+hash-addressed UMD after a controlled adapter restart:
+
+```text
+SHA256 0708FD6F708EB31CD4BA0F75072DEEB48B5048950DA8813485F9AA411ECE36FB
+C:\ProgramData\HeliosUmd\helios_umd_0708fd6f708eb31c.dll
+```
+
+The fresh `Exit8-Win64-Shipping.exe` process loaded that exact module. Its UMD
+log built a 1280x800 snapshot ring with `src_fmt=24 scanout_fmt=28`, with no
+ring, copy, cache, or private-data failures. A raw RFB capture from QEMU—not a
+guest-side screenshot—then showed the normal corridor with correct neutral
+colors. The final clean capture had 823,640/1,024,000 non-black pixels
+(80.43%), versus 0/16,000 sampled pixels lit in the failed intermediate build.
+After a later WinBoat container recreation and fresh VM boot, the user repeated
+the exclusive-fullscreen test through VNC and confirmed that The Exit 8 still
+rendered correctly. Windowed and borderless behavior remained unaffected.
+
+## Follow-up regression plan
+
+- Add a small D3D11 fullscreen probe that presents known format-24 gray/color
+  ramps. Compare guest and host pixels, including the four values above.
+- Exercise The Exit 8 in exclusive fullscreen, borderless, and windowed modes.
+- Regression-test an ordinary 8-bit exclusive-fullscreen title and the DWM
+  desktop/windowed-Blt path.
+- Assert that every published AR24 surface has a format-28/87/88 producer or an
+  explicit completed conversion from format 24.
+- Assert that cross-format `RotateResourceIdentities` input is rejected and
+  counted rather than silently rotated.

--- a/umd/bridge/dxvk_bridge.cpp
+++ b/umd/bridge/dxvk_bridge.cpp
@@ -1036,6 +1036,41 @@ bool HeliosDxvkDevice::rotate_resource_backings(
         images.push_back(texture->GetImage());
       }
 
+      // DXGI may only rotate identities within one compatible swapchain ring.
+      // invalidateImage replaces the storage but intentionally leaves the
+      // stable DxvkImage's format/shape metadata in place, so accepting a
+      // mixed ring would attach (for example) packed RGB10A2 storage to a
+      // BGRA8 image and make every downstream user reinterpret its bytes.
+      const auto& expected = images[0]->info();
+      for (std::size_t i = 1; i < images.size(); ++i) {
+        const auto& actual = images[i]->info();
+        if (actual.type        != expected.type
+         || actual.format      != expected.format
+         || actual.sampleCount != expected.sampleCount
+         || actual.extent.width  != expected.extent.width
+         || actual.extent.height != expected.extent.height
+         || actual.extent.depth  != expected.extent.depth
+         || actual.numLayers   != expected.numLayers
+         || actual.mipLevels   != expected.mipLevels) {
+          char msg[320];
+          std::snprintf(msg, sizeof(msg),
+            "rotate_resource_backings: incompatible slot %zu/%zu "
+            "expected fmt=%u extent=%ux%ux%u samples=%u layers=%u mips=%u; "
+            "got fmt=%u extent=%ux%ux%u samples=%u layers=%u mips=%u",
+            i, images.size(),
+            static_cast<unsigned>(expected.format),
+            expected.extent.width, expected.extent.height, expected.extent.depth,
+            static_cast<unsigned>(expected.sampleCount),
+            expected.numLayers, expected.mipLevels,
+            static_cast<unsigned>(actual.format),
+            actual.extent.width, actual.extent.height, actual.extent.depth,
+            static_cast<unsigned>(actual.sampleCount),
+            actual.numLayers, actual.mipLevels);
+          umd_log(msg);
+          return false;
+        }
+      }
+
       // CS-side identity rotation (18th session), mirroring upstream
       // D3D11SwapChain::RotateBackBuffers: swap the storages ON the CS thread
       // via DxvkContext::invalidateImage. No GPU drain is needed — every
@@ -1195,6 +1230,99 @@ bool HeliosDxvkDevice::rotate_resource_backings(
       // The storage swap itself (resource[i] takes resource[i+1]'s, the last
       // takes the first's) executes in the injected CS command above.
       return true;
+  });
+}
+
+std::int32_t HeliosDxvkDevice::dxgi_blt_convert(
+    std::size_t dst_resource_ptr,
+    std::uint32_t dst_subresource,
+    std::uint32_t dst_x,
+    std::uint32_t dst_y,
+    std::size_t src_resource_ptr,
+    std::uint32_t src_subresource,
+    bool use_src_box,
+    std::uint32_t src_left,
+    std::uint32_t src_top,
+    std::uint32_t src_right,
+    std::uint32_t src_bottom) const {
+  if (!impl || !impl->context || !dst_resource_ptr || !src_resource_ptr)
+    return -1;
+
+  return bridge_guard("dxgi_blt_convert", -1, [&]() -> std::int32_t {
+      auto* dstTex = dxvk::GetCommonTexture(
+        reinterpret_cast<ID3D11Resource*>(dst_resource_ptr));
+      auto* srcTex = dxvk::GetCommonTexture(
+        reinterpret_cast<ID3D11Resource*>(src_resource_ptr));
+      if (!dstTex || !dstTex->GetImage() || !srcTex || !srcTex->GetImage()) {
+        umd_log("dxgi_blt_convert: non-texture resource");
+        return -1;
+      }
+      if (dst_subresource >= dstTex->CountSubresources()
+       || src_subresource >= srcTex->CountSubresources()) {
+        umd_log("dxgi_blt_convert: subresource out of range");
+        return -1;
+      }
+
+      dxvk::Rc<dxvk::DxvkImage> dstImage = dstTex->GetImage();
+      dxvk::Rc<dxvk::DxvkImage> srcImage = srcTex->GetImage();
+      const auto* dstFormat = dstImage->formatInfo();
+      const auto* srcFormat = srcImage->formatInfo();
+      if (!dstFormat || !srcFormat
+       || dstFormat->aspectMask != VK_IMAGE_ASPECT_COLOR_BIT
+       || srcFormat->aspectMask != VK_IMAGE_ASPECT_COLOR_BIT
+       || dstImage->info().sampleCount != VK_SAMPLE_COUNT_1_BIT
+       || srcImage->info().sampleCount != VK_SAMPLE_COUNT_1_BIT) {
+        umd_log("dxgi_blt_convert: needs single-sampled color images");
+        return -1;
+      }
+
+      const VkImageSubresourceLayers dstLayers = dxvk::vk::makeSubresourceLayers(
+        dstTex->GetSubresourceFromIndex(dstFormat->aspectMask, dst_subresource));
+      const VkImageSubresourceLayers srcLayers = dxvk::vk::makeSubresourceLayers(
+        srcTex->GetSubresourceFromIndex(srcFormat->aspectMask, src_subresource));
+      const VkExtent3D srcMip = srcTex->MipLevelExtent(srcLayers.mipLevel);
+      const VkExtent3D dstMip = dstTex->MipLevelExtent(dstLayers.mipLevel);
+
+      VkOffset3D srcOffset = { 0, 0, 0 };
+      VkExtent3D extent = srcMip;
+      if (use_src_box) {
+        if (src_right <= src_left || src_bottom <= src_top
+         || src_right > srcMip.width || src_bottom > srcMip.height) {
+          umd_log("dxgi_blt_convert: invalid source rectangle");
+          return -1;
+        }
+        srcOffset = {
+          static_cast<std::int32_t>(src_left),
+          static_cast<std::int32_t>(src_top),
+          0,
+        };
+        extent = { src_right - src_left, src_bottom - src_top, 1u };
+      }
+      if (dst_x > dstMip.width || dst_y > dstMip.height
+       || extent.width > dstMip.width - dst_x
+       || extent.height > dstMip.height - dst_y
+       || extent.depth != 1u) {
+        umd_log("dxgi_blt_convert: destination region out of bounds");
+        return -1;
+      }
+
+      static_cast<dxvk::D3D11ImmediateContext*>(impl->context)->HeliosConvertImage(
+        dstImage, dstLayers,
+        VkOffset3D { static_cast<std::int32_t>(dst_x), static_cast<std::int32_t>(dst_y), 0 },
+        srcImage, srcLayers, srcOffset, extent);
+      static std::atomic<std::uint32_t> s_converted{0};
+      const std::uint32_t n = s_converted.fetch_add(1, std::memory_order_relaxed) + 1;
+      if (n <= 4 || (n % 16384u) == 0) {
+        char msg[192];
+        std::snprintf(msg, sizeof(msg),
+          "dxgi_blt_convert: queued #%u src_vk=%u dst_vk=%u extent=%ux%u",
+          n,
+          static_cast<unsigned>(srcImage->info().format),
+          static_cast<unsigned>(dstImage->info().format),
+          extent.width, extent.height);
+        umd_log(msg);
+      }
+      return 0;
   });
 }
 

--- a/umd/bridge/dxvk_bridge.h
+++ b/umd/bridge/dxvk_bridge.h
@@ -141,6 +141,24 @@ struct HeliosDxvkDevice {
       const std::size_t* d3d11_resource_ptrs,
       std::size_t count) const;
 
+  // DXGI pfnBlt/pfnBlt1 cross-format path. Records a numerical color
+  // conversion rather than CopySubresourceRegion's equal-texel-size bit copy.
+  // `use_src_box == false` selects the source mip's complete extent.
+  // Returns 0 on success and a negative value without recording work when any
+  // resource/subresource/region precondition is invalid.
+  std::int32_t dxgi_blt_convert(
+      std::size_t dst_resource_ptr,
+      std::uint32_t dst_subresource,
+      std::uint32_t dst_x,
+      std::uint32_t dst_y,
+      std::size_t src_resource_ptr,
+      std::uint32_t src_subresource,
+      bool use_src_box,
+      std::uint32_t src_left,
+      std::uint32_t src_top,
+      std::uint32_t src_right,
+      std::uint32_t src_bottom) const;
+
   // Cross-process present ordering, PRODUCER side. Records a signal on this
   // device's named present timeline at the presented frame's GPU completion and
   // publishes (resid -> pid, fenceId, value), so a consumer compositing this

--- a/umd/src/bridge.rs
+++ b/umd/src/bridge.rs
@@ -172,6 +172,23 @@ mod ffi {
             d3d11_resource_ptrs: *const usize,
             count: usize,
         ) -> bool;
+        /// DXGI Blt cross-format path. Numerically converts the selected
+        /// source region instead of preserving equal-sized packed texel bits.
+        /// `use_src_box == false` selects the complete source mip.
+        unsafe fn dxgi_blt_convert(
+            self: &HeliosDxvkDevice,
+            dst_resource_ptr: usize,
+            dst_subresource: u32,
+            dst_x: u32,
+            dst_y: u32,
+            src_resource_ptr: usize,
+            src_subresource: u32,
+            use_src_box: bool,
+            src_left: u32,
+            src_top: u32,
+            src_right: u32,
+            src_bottom: u32,
+        ) -> i32;
         /// Present-path frame-completion gate: bounded wait (timeout_us)
         /// until the current flush's submission completes on the GPU, so the
         /// IddCx consumer never copies a buffer whose writes are in flight.
@@ -702,6 +719,42 @@ impl BridgeDevice {
     ) -> bool {
         self.get()
             .is_some_and(|d| unsafe { d.rotate_resource_backings(d3d11_resource_ptrs, count) })
+    }
+
+    /// # Safety
+    /// Both resource words must be live `ID3D11Resource*` values belonging to
+    /// this bridge device. Subresource and region bounds are validated again
+    /// by the C++ side before it records any work.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) unsafe fn dxgi_blt_convert(
+        &self,
+        dst: DstRes,
+        dst_subresource: u32,
+        dst_x: u32,
+        dst_y: u32,
+        src: SrcRes,
+        src_subresource: u32,
+        use_src_box: bool,
+        src_left: u32,
+        src_top: u32,
+        src_right: u32,
+        src_bottom: u32,
+    ) -> i32 {
+        self.get().map_or(-1, |d| unsafe {
+            d.dxgi_blt_convert(
+                dst.0,
+                dst_subresource,
+                dst_x,
+                dst_y,
+                src.0,
+                src_subresource,
+                use_src_box,
+                src_left,
+                src_top,
+                src_right,
+                src_bottom,
+            )
+        })
     }
 
     /// # Safety

--- a/umd/src/device_funcs.rs
+++ b/umd/src/device_funcs.rs
@@ -105,7 +105,12 @@ impl Drop for SnapshotSlot {
 pub struct SnapshotRing {
     pub width: u32,
     pub height: u32,
-    pub dxgi_format: u32,
+    /// Format of the application's presented source. This is part of the
+    /// cache key because it determines whether the snapshot copy converts.
+    pub source_dxgi_format: u32,
+    /// Scan-out-safe format of every slot in this ring. It normally matches
+    /// the source, except that packed 10-bit sources are converted to RGBA8.
+    pub scanout_dxgi_format: u32,
     /// Direct scan-out snapshots retain SHADER_READ_ONLY_OPTIMAL for QEMU;
     /// WindowedBlt snapshots are born GENERAL for the KMD transfer importer.
     /// The two contracts must never share slots even at identical geometry.

--- a/umd/src/forward/present.rs
+++ b/umd/src/forward/present.rs
@@ -1916,14 +1916,24 @@ pub(crate) static PRESENT1_LOG_COUNT: LogThrottle = LogThrottle::new();
 pub(crate) static DXGI13_RESERVED_LOG_COUNT: LogThrottle = LogThrottle::new();
 pub(crate) const DXGI_MPO_MAX_PLANES: u32 = 16;
 
+/// Classify the value semantics DXGI Blt needs from the two resource formats.
+/// `None` keeps unknown/non-texture formats out of the custom image path;
+/// unequal known formats must be numerically converted, never copied as four
+/// opaque bytes merely because their Vulkan texel blocks have equal size.
+fn dxgi_blt_needs_conversion(src_format: u32, dst_format: u32) -> Option<bool> {
+    (src_format != 0 && dst_format != 0).then_some(src_format != dst_format)
+}
+
 pub(crate) unsafe extern "C" fn dxgi_blt(arg: *mut ddi::DXGI_DDI_ARG_BLT) -> i32 {
     if arg.is_null() {
         return 0;
     }
     let a = &*arg;
-    let Some(context) = d3d11_context(dxgi_device_handle(a.hDevice)) else {
+    let h = dxgi_device_handle(a.hDevice);
+    let Some(context) = d3d11_context(h) else {
         return 0;
     };
+
     let dst_h = dxgi_resource_handle(a.hDstResource);
     let src_h = dxgi_resource_handle(a.hSrcResource);
     let (Some(dst), Some(src)) = (load_resource(dst_h), load_resource(src_h)) else {
@@ -1934,6 +1944,8 @@ pub(crate) unsafe extern "C" fn dxgi_blt(arg: *mut ddi::DXGI_DDI_ARG_BLT) -> i32
         );
         return 0;
     };
+    let src_format = resource_dxgi_format(src_h).0 as u32;
+    let dst_format = resource_dxgi_format(dst_h).0 as u32;
 
     if let Some(n) = BLT_LOG_COUNT.first_n_then_every_from_one(128, 512) {
         let mut src_desc = D3D11_TEXTURE2D_DESC::default();
@@ -1967,9 +1979,49 @@ pub(crate) unsafe extern "C" fn dxgi_blt(arg: *mut ddi::DXGI_DDI_ARG_BLT) -> i32
         );
     }
 
-    // The DXGI 1.0 blit DDI has no source rectangle. For DWM/windowed present
-    // setup the runtime uses it to move between compatible proxy/front-buffer
-    // surfaces, so a full subresource copy is the safest baseline.
+    // DXGI Blt, unlike D3D11 CopySubresourceRegion, carries conversion
+    // semantics. The old unconditional copy was a raw bit transfer for
+    // equal-sized color formats: an R10G10B10A2 fullscreen backbuffer copied
+    // into an RGBA8 proxy retained its packed words and was later scanned out
+    // as ordinary bytes. Route every known cross-format pair through DXVK's
+    // explicit framebuffer conversion and fail closed if it cannot be queued.
+    if dxgi_blt_needs_conversion(src_format, dst_format) == Some(true) {
+        let Some(dev) = helios_device(h) else {
+            log_error!(
+                "DXGI Blt: cross-format conversion has no device src_fmt={} dst_fmt={}",
+                src_format,
+                dst_format
+            );
+            return E_FAIL;
+        };
+        let rc = dev.dxvk.dxgi_blt_convert(
+            DstRes(resource_com_raw(dst_h)),
+            a.DstSubresource,
+            a.DstLeft,
+            a.DstTop,
+            SrcRes(resource_com_raw(src_h)),
+            a.SrcSubresource,
+            false,
+            0,
+            0,
+            0,
+            0,
+        );
+        if rc != 0 {
+            log_error!(
+                "DXGI Blt: cross-format conversion refused rc={} src_fmt={} dst_fmt={}",
+                rc,
+                src_format,
+                dst_format
+            );
+            return DXGI_ERROR_UNSUPPORTED;
+        }
+        context.Flush();
+        return 0;
+    }
+
+    // The DXGI 1.0 blit DDI has no source rectangle. Same-format proxy/front
+    // buffers retain the regular full-subresource copy path.
     context.CopySubresourceRegion(
         &*dst,
         a.DstSubresource,
@@ -1989,7 +2041,8 @@ pub(crate) unsafe extern "C" fn dxgi_blt1(arg: *mut ddi::DXGI_DDI_ARG_BLT1) -> i
         return 0;
     }
     let a = &*arg;
-    let Some(context) = d3d11_context(dxgi_device_handle(a.hDevice)) else {
+    let h = dxgi_device_handle(a.hDevice);
+    let Some(context) = d3d11_context(h) else {
         return 0;
     };
     let dst_h = dxgi_resource_handle(a.hDstResource);
@@ -2004,14 +2057,8 @@ pub(crate) unsafe extern "C" fn dxgi_blt1(arg: *mut ddi::DXGI_DDI_ARG_BLT1) -> i
     };
 
     const BLT_RESOLVE: u32 = 0x1;
-    const BLT_CONVERT: u32 = 0x2;
     const BLT_STRETCH: u32 = 0x4;
     let flags = a.Flags.__bindgen_anon_1.Value;
-    if flags & BLT_CONVERT != 0 {
-        log_error!("DXGI Blt1: convert unsupported flags=0x{flags:x}");
-        return DXGI_ERROR_UNSUPPORTED;
-    }
-
     let src_w = a.SrcRight.saturating_sub(a.SrcLeft);
     let src_h_px = a.SrcBottom.saturating_sub(a.SrcTop);
     let dst_w = a.DstRight.saturating_sub(a.DstLeft);
@@ -2040,6 +2087,48 @@ pub(crate) unsafe extern "C" fn dxgi_blt1(arg: *mut ddi::DXGI_DDI_ARG_BLT1) -> i
         );
         return DXGI_ERROR_UNSUPPORTED;
     }
+
+    let src_format = resource_dxgi_format(src_h).0 as u32;
+    let dst_format = resource_dxgi_format(dst_h).0 as u32;
+    if dxgi_blt_needs_conversion(src_format, dst_format) == Some(true) {
+        let Some(dev) = helios_device(h) else {
+            log_error!(
+                "DXGI Blt1: cross-format conversion has no device src_fmt={} dst_fmt={}",
+                src_format,
+                dst_format
+            );
+            return E_FAIL;
+        };
+        let use_src_box = a.SrcRight > a.SrcLeft && a.SrcBottom > a.SrcTop;
+        let rc = dev.dxvk.dxgi_blt_convert(
+            DstRes(resource_com_raw(dst_h)),
+            a.DstSubresource,
+            a.DstLeft,
+            a.DstTop,
+            SrcRes(resource_com_raw(src_h)),
+            a.SrcSubresource,
+            use_src_box,
+            a.SrcLeft,
+            a.SrcTop,
+            a.SrcRight,
+            a.SrcBottom,
+        );
+        if rc != 0 {
+            log_error!(
+                "DXGI Blt1: cross-format conversion refused rc={} src_fmt={} dst_fmt={} flags=0x{:x}",
+                rc,
+                src_format,
+                dst_format,
+                flags
+            );
+            return DXGI_ERROR_UNSUPPORTED;
+        }
+        context.Flush();
+        return 0;
+    }
+
+    // BLT_CONVERT with identical formats is a semantic no-op; keeping it on
+    // the ordinary copy path avoids a render pass without changing values.
 
     let bx;
     let bx_ptr = if a.SrcRight > a.SrcLeft && a.SrcBottom > a.SrcTop {
@@ -2525,4 +2614,30 @@ pub(crate) unsafe extern "C" fn dxgi_check_present_duration_support(
         );
     }
     0
+}
+
+#[cfg(test)]
+mod dxgi_blt_format_tests {
+    use super::dxgi_blt_needs_conversion;
+
+    #[test]
+    fn rgb10_to_rgba8_is_a_numeric_conversion() {
+        assert_eq!(dxgi_blt_needs_conversion(24, 28), Some(true));
+    }
+
+    #[test]
+    fn rgba_and_bgra_are_not_bitwise_interchangeable() {
+        assert_eq!(dxgi_blt_needs_conversion(28, 87), Some(true));
+    }
+
+    #[test]
+    fn identical_formats_keep_the_copy_path() {
+        assert_eq!(dxgi_blt_needs_conversion(87, 87), Some(false));
+    }
+
+    #[test]
+    fn unknown_format_does_not_enter_the_image_converter() {
+        assert_eq!(dxgi_blt_needs_conversion(0, 87), None);
+        assert_eq!(dxgi_blt_needs_conversion(24, 0), None);
+    }
 }

--- a/umd/src/forward/snapshot.rs
+++ b/umd/src/forward/snapshot.rs
@@ -71,6 +71,10 @@ pub(crate) struct SnapshotPlan {
     pub(crate) height: u32,
     pub(crate) pitch: u32,
     pub(crate) plane_offset: u64,
+    /// Format the presented application resource had when the copy was
+    /// recorded. Used only by the stale-private guard.
+    pub(crate) source_dxgi_format: u32,
+    /// Format of the converted snapshot resource published to the KMD.
     pub(crate) dxgi_format: u32,
     pub(crate) venus_alloc_size: u64,
     pub(crate) memory_type_index: u32,
@@ -103,6 +107,20 @@ pub(crate) static SNAP_CACHE_REFUSALS: AtomicUsize = AtomicUsize::new(0);
 /// was recorded against. The stale-descriptor guard's loud half.
 pub(crate) static SNAP_PRIVATE_SKIPS: AtomicUsize = AtomicUsize::new(0);
 
+/// Select the format carried by a scan-out snapshot.
+///
+/// The KMD/QEMU direct-primary contract consumes ordinary 32-bit AR24/XR24
+/// pixels. Packed R10G10B10A2 is also four bytes per texel, but publishing its
+/// words as AR24 reinterprets bit fields as byte channels. Keep format 24 out
+/// of the scan-out allocator and convert it numerically into RGBA8 instead.
+fn snapshot_scanout_format(source_dxgi_format: u32) -> Option<u32> {
+    match source_dxgi_format {
+        24 => Some(28),
+        28 | 87 | 88 => Some(source_dxgi_format),
+        _ => None,
+    }
+}
+
 fn counter_summary() -> String {
     format!(
         "sub={} ring_fails={} copy_fails={} cache_refusals={} private_skips={}",
@@ -127,7 +145,8 @@ unsafe fn build_ring(
     h: Hdevice,
     width: u32,
     height: u32,
-    dxgi_format: u32,
+    source_dxgi_format: u32,
+    scanout_dxgi_format: u32,
     purpose: SnapshotPurpose,
 ) -> Option<SnapshotRing> {
     // The composition-surface baseline. Sharing/export is driven by the
@@ -139,7 +158,7 @@ unsafe fn build_ring(
         let Some((res, row_pitch, plane_offset)) = dev.dxvk.create_scanout_texture2d(
             width,
             height,
-            dxgi_format,
+            scanout_dxgi_format,
             bind,
             0,
             purpose == SnapshotPurpose::WindowedBlt,
@@ -147,10 +166,11 @@ unsafe fn build_ring(
             let n = SNAP_RING_CREATE_FAILS.fetch_add(1, Ordering::Relaxed);
             if n < 16 || n % 512 == 0 {
                 log_error!(
-                    "scanout-snapshot: ring slot {i} create FAILED {}x{} fmt={} ({})",
+                    "scanout-snapshot: ring slot {i} create FAILED {}x{} src_fmt={} scanout_fmt={} ({})",
                     width,
                     height,
-                    dxgi_format,
+                    source_dxgi_format,
+                    scanout_dxgi_format,
                     counter_summary()
                 );
             }
@@ -209,11 +229,12 @@ unsafe fn build_ring(
         });
     }
     log_error!(
-        "scanout-snapshot: ring built purpose={:?} {}x{} fmt={} resids=[{}, {}, {}, {}] pitch={}",
+        "scanout-snapshot: ring built purpose={:?} {}x{} src_fmt={} scanout_fmt={} resids=[{}, {}, {}, {}] pitch={}",
         purpose,
         width,
         height,
-        dxgi_format,
+        source_dxgi_format,
+        scanout_dxgi_format,
         slots[0].resid,
         slots[1].resid,
         slots[2].resid,
@@ -223,7 +244,8 @@ unsafe fn build_ring(
     Some(SnapshotRing {
         width,
         height,
-        dxgi_format,
+        source_dxgi_format,
+        scanout_dxgi_format,
         purpose,
         slots,
         next: 0,
@@ -277,12 +299,23 @@ pub(crate) unsafe fn snapshot_for_present(
         }
         return None;
     }
+    let Some(scanout_dxgi_format) = snapshot_scanout_format(dxgi_format) else {
+        let n = SNAP_RING_CREATE_FAILS.fetch_add(1, Ordering::Relaxed);
+        if n < 16 || n % 512 == 0 {
+            log_error!(
+                "scanout-snapshot: unsupported source format {} ({})",
+                dxgi_format,
+                counter_summary()
+            );
+        }
+        return None;
+    };
 
     let mut cache = dev.owned.snapshot_rings.borrow_mut();
     let mut ring_index = cache.rings.iter().position(|ring| {
         ring.width == width
             && ring.height == height
-            && ring.dxgi_format == dxgi_format
+            && ring.source_dxgi_format == dxgi_format
             && ring.purpose == purpose
     });
     if ring_index.is_none() {
@@ -309,7 +342,15 @@ pub(crate) unsafe fn snapshot_for_present(
             }
             return None;
         }
-        let Some(ring) = build_ring(dev, h, width, height, dxgi_format, purpose) else {
+        let Some(ring) = build_ring(
+            dev,
+            h,
+            width,
+            height,
+            dxgi_format,
+            scanout_dxgi_format,
+            purpose,
+        ) else {
             return None; // counted + logged in build_ring
         };
         let ring_bytes = ring
@@ -359,7 +400,8 @@ pub(crate) unsafe fn snapshot_for_present(
                 height: ring.height,
                 pitch: slot.pitch,
                 plane_offset: slot.plane_offset,
-                dxgi_format: ring.dxgi_format,
+                source_dxgi_format: ring.source_dxgi_format,
+                dxgi_format: ring.scanout_dxgi_format,
                 venus_alloc_size: slot.alloc_size,
                 memory_type_index: slot.memory_type_index,
                 purpose,
@@ -510,7 +552,7 @@ pub(crate) fn apply_snapshot_override(
     };
     if private.width != plan.width
         || private.height != plan.height
-        || private.dxgi_format != plan.dxgi_format
+        || private.dxgi_format != plan.source_dxgi_format
     {
         let n = SNAP_PRIVATE_SKIPS.fetch_add(1, Ordering::Relaxed);
         if n < 16 || n % 512 == 0 {
@@ -522,7 +564,7 @@ pub(crate) fn apply_snapshot_override(
                 private.dxgi_format,
                 plan.width,
                 plan.height,
-                plan.dxgi_format,
+                plan.source_dxgi_format,
                 counter_summary()
             );
         }
@@ -538,4 +580,26 @@ pub(crate) fn apply_snapshot_override(
     private.reserved |= HELIOS_PRESENT_PRIVATE_FLAG_SNAPSHOT;
     private.snapshot_memory_type_index = plan.memory_type_index;
     private.snapshot_purpose = HELIOS_PRESENT_SNAPSHOT_PURPOSE_NONE;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::snapshot_scanout_format;
+
+    #[test]
+    fn packed_ten_bit_snapshot_converts_to_rgba8() {
+        assert_eq!(snapshot_scanout_format(24), Some(28));
+    }
+
+    #[test]
+    fn native_scanout_formats_are_preserved() {
+        assert_eq!(snapshot_scanout_format(28), Some(28));
+        assert_eq!(snapshot_scanout_format(87), Some(87));
+        assert_eq!(snapshot_scanout_format(88), Some(88));
+    }
+
+    #[test]
+    fn unsupported_snapshot_formats_fail_closed() {
+        assert_eq!(snapshot_scanout_format(10), None);
+    }
 }


### PR DESCRIPTION
## Summary

- classify unequal known DXGI formats as numeric conversions in `Blt`/`Blt1`
- convert R10G10B10A2 fullscreen snapshots into the canonical RGBA8 scanout format
- reject mixed-format or mixed-shape resource identity rotation
- pin the merged DXVK native-view conversion path from winboat-org/dxvk#3
- add the completed Exit 8 investigation and regression plan

## Root cause

Exclusive fullscreen copied packed RGB10A2 words into an AR24/RGBA8-labelled scanout. QEMU correctly displayed the supplied bytes, producing the stable neon/posterized artifact. A raw copy is legal for equal-sized Vulkan color texels but does not perform the required numeric conversion.

## Validation

- complete signed Windows driver package built successfully
- deployed UMD SHA256: `0708FD6F708EB31CD4BA0F75072DEEB48B5048950DA8813485F9AA411ECE36FB`
- fresh Exit 8 process loaded that exact DLL
- raw QEMU RFB capture showed correct neutral colors
- user reconfirmed exclusive fullscreen through VNC after a later container recreation and fresh VM boot
- `git diff --check` passes in Helios and DXVK
- Linux cannot compile the Windows-only UMD test target; the complete Windows build compiled the added code